### PR TITLE
FISH-13066 : some improvements in the javadocs

### DIFF
--- a/api/src/main/java/jakarta/ai/agent/Action.java
+++ b/api/src/main/java/jakarta/ai/agent/Action.java
@@ -106,6 +106,8 @@ import java.lang.annotation.Target;
  * @see Decision
  * @see Outcome
  * @see LargeLanguageModel
+ *
+ * @since 1.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/ai/agent/Agent.java
+++ b/api/src/main/java/jakarta/ai/agent/Agent.java
@@ -25,13 +25,15 @@ import java.lang.annotation.Target;
  * additional annotations.
  * <p>
  * Agents support two scope annotations: {@link WorkflowScoped} and 
- * @ApplicationScoped. If no scope annotation is present on the class, the 
+ * {@code @ApplicationScoped}. If no scope annotation is present on the class, the
  * agent will be assumed to be {@link WorkflowScoped}.
  * <p>
  * A workflow context will still be created for each workflow execution even 
  * when the agent is @ApplicationScoped, beginning with a trigger and in most 
  * cases ending with an outcome.
  * </p>
+ *
+ * @since 1.0
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -40,8 +42,8 @@ public @interface Agent {
     /**
      * The agent's name.
      * <p>
-     * If not specified, the agent's class name in camelCase will be used as a 
-     * default.
+     * If not specified, the simple class name with the first letter lowercased
+     * will be used as a default (e.g., {@code MyAgent} becomes {@code myAgent}).
      */
     String name() default "";
 

--- a/api/src/main/java/jakarta/ai/agent/Decision.java
+++ b/api/src/main/java/jakarta/ai/agent/Decision.java
@@ -103,6 +103,8 @@ import java.lang.annotation.Target;
  * @see Trigger
  * @see Action
  * @see Outcome
+ *
+ * @since 1.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/ai/agent/HandleException.java
+++ b/api/src/main/java/jakarta/ai/agent/HandleException.java
@@ -141,6 +141,8 @@ import java.lang.annotation.Target;
  * @see Decision
  * @see Outcome
  * @see LargeLanguageModel
+ *
+ * @since 1.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/ai/agent/LLMException.java
+++ b/api/src/main/java/jakarta/ai/agent/LLMException.java
@@ -26,6 +26,8 @@ package jakarta.ai.agent;
  * <p>
  * As a runtime exception, it does not require explicit handling but can be 
  * caught by {@link HandleException} annotated methods in agent workflows.
+ *
+ * @since 1.0
  */
 public class LLMException extends RuntimeException {
 

--- a/api/src/main/java/jakarta/ai/agent/LargeLanguageModel.java
+++ b/api/src/main/java/jakarta/ai/agent/LargeLanguageModel.java
@@ -33,6 +33,10 @@ package jakarta.ai.agent;
  * LLM features in a standardized way. This is very similar to how Jakarta 
  * Persistence works with multiple providers and a common set of configuration 
  * properties.
+ *
+ * @see LLMException
+ *
+ * @since 1.0
  */
 public interface LargeLanguageModel {
 

--- a/api/src/main/java/jakarta/ai/agent/Outcome.java
+++ b/api/src/main/java/jakarta/ai/agent/Outcome.java
@@ -111,6 +111,8 @@ import java.lang.annotation.Target;
  * @see Decision
  * @see Trigger
  * @see LargeLanguageModel
+ *
+ * @since 1.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/ai/agent/Result.java
+++ b/api/src/main/java/jakarta/ai/agent/Result.java
@@ -14,9 +14,15 @@ package jakarta.ai.agent;
 
 /**
  * Represents the result of a decision or workflow step in an agent.
- * <p>
- * The 'success' flag indicates a positive or negative result, and 'details'
- * can hold additional information, such as error messages, domain objects,
- * or context.
+ *
+ * @param success {@code true} if the decision or step succeeded,
+ *                {@code false} otherwise. When used as a
+ *                {@link Decision @Decision} return type, {@code true}
+ *                means the workflow proceeds and {@code false} stops it.
+ * @param details can hold additional information, such as error messages, domain objects,
+ *                or context.
+ *
+ * @since 1.0
  */
-public record Result(boolean success, Object details) {}
+public record Result(boolean success, Object details) {
+}

--- a/api/src/main/java/jakarta/ai/agent/Trigger.java
+++ b/api/src/main/java/jakarta/ai/agent/Trigger.java
@@ -109,6 +109,8 @@ import java.lang.annotation.Target;
  * @see Action
  * @see Outcome
  * @see LargeLanguageModel
+ *
+ * @since 1.0
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/ai/agent/WorkflowScoped.java
+++ b/api/src/main/java/jakarta/ai/agent/WorkflowScoped.java
@@ -50,6 +50,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     private Map<String, Object> cache = new HashMap<>();
  * }
  * }</pre>
+ *
+ * @see Agent
+ *
+ * @since 1.0
  */
 @Target({ TYPE, METHOD, FIELD })
 @Retention(RUNTIME)

--- a/api/src/main/java/jakarta/ai/agent/package-info.java
+++ b/api/src/main/java/jakarta/ai/agent/package-info.java
@@ -210,5 +210,7 @@
  * @see jakarta.ai.agent.Outcome
  * @see jakarta.ai.agent.LargeLanguageModel
  * @see jakarta.ai.agent.WorkflowScoped
+ *
+ * @since 1.0
  */
 package jakarta.ai.agent;


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                                                                                                                                                                                                                                                                           
- Add `@since` 1.0 tags to all public API types and annotations (Action, Agent, Decision, HandleException, LLMException, LargeLanguageModel, Outcome, Result, Trigger, WorkflowScoped, and package-info)                          
- Improve the Result record documentation by adding proper `@param` tags for success and details fields                                                                                                                           
- Fix the `Agent.name()` default description to clarify the naming convention (simple class name with first letter lowercased)                                                                                                    
- Fix a broken Javadoc reference in Agent — changed `@ApplicationScoped` to `{@code @ApplicationScoped}`                                                                                                                          
- Add missing `@see` cross-references in `LargeLanguageModel` and `WorkflowScoped`