### PR TITLE
added module-info #24

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+/**
+ * Jakarta Agentic AI API module.
+ * Provides a vendor-neutral API for building agentic AI applications on Jakarta EE runtimes.
+ *
+ * @since 1.0
+ */
+module jakarta.ai.agent {
+    requires jakarta.cdi;
+
+    exports jakarta.ai.agent;
+}


### PR DESCRIPTION
Added module-info.java: 
Defines the jakarta.ai.agent module with dependencies on jakarta.cdi and exports the jakarta.ai.agent package.
