### PR TITLE
FISH-13489: Create TCK internal infrastructure for behavioral testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
                   restore-keys: ${{ runner.os }}-m2
 
             - name: Build
-              run: mvn clean install
+              run: mvn clean install -Pweld-embedded
 
             - name: License Check
               run: mvn org.eclipse.dash:license-tool-plugin:license-check -Pdash-licenses -Ddash.summary=DEPENDENCIES -Ddash.fail=true

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -102,10 +102,26 @@
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Tests.java</include>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -144,6 +160,23 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>weld-embedded</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-weld-embedded</artifactId>
+                    <version>3.0.2.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld</groupId>
+                    <artifactId>weld-core-impl</artifactId>
+                    <version>5.1.5.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
         <!-- Profile for generating API signature files -->
         <profile>
             <id>signature-generation</id>

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/AgentAnnotationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/AgentAnnotationTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.agent;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Agent;
 
 import java.lang.annotation.ElementType;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p>These tests verify that the @Agent annotation conforms to the
  * Jakarta Agentic AI 1.0 specification requirements.
  */
+@Standalone
 public class AgentAnnotationTests {
 
     @Assertion(id = "AGENTICAI-AGENT-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/LLMExceptionTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/LLMExceptionTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.agent;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.LLMException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p>These tests verify that the LLMException class conforms to the
  * Jakarta Agentic AI 1.0 specification requirements.
  */
+@Standalone
 public class LLMExceptionTests {
 
     @Assertion(id = "AGENTICAI-LLMEXCEPTION-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/LargeLanguageModelTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/LargeLanguageModelTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.agent;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.LargeLanguageModel;
 
 import java.lang.reflect.Method;
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Jakarta Agentic AI 1.0 specification requirements. This interface provides
  * a lightweight facade for accessing LLM capabilities.
  */
+@Standalone
 public class LargeLanguageModelTests {
 
     @Assertion(id = "AGENTICAI-LLM-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/cdi/WorkflowScopedTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/cdi/WorkflowScopedTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.cdi;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 
 import jakarta.ai.agent.WorkflowScoped;
 import jakarta.enterprise.context.NormalScope;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>These tests verify that the @WorkflowScoped annotation conforms to the Jakarta Agentic AI
  * 1.0 specification requirements for custom CDI scopes.
  */
+@Standalone
 public class WorkflowScopedTests {
 
     @Assertion(id = "AGENTICAI-WORKFLOWSCOPED-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/integration/AgentSmokeTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/integration/AgentSmokeTest.java
@@ -1,0 +1,119 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.integration;
+
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Deployed;
+import ee.jakarta.tck.ai.agent.framework.stub.LargeLanguageModelStub;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end smoke test for the Jakarta Agentic AI TCK infrastructure.
+ *
+ * <p>This test validates that the deployment archive boots, that the CDI
+ * container picks up the agent and observes the trigger event, and that the
+ * internal infrastructure (stub + trace recorder) is wired correctly.</p>
+ *
+ * <p><b>Scope limitation</b>: in the absence of a Reference Implementation
+ * of the Agentic AI orchestration engine, only the {@code @Trigger} phase
+ * is invoked (it is registered as a CDI observer via {@code @Observes}).
+ * The {@code @Action} and {@code @Outcome} phases require an engine that
+ * scans the agent and dispatches subsequent phases — see
+ * {@link #fullLifecycleRequiresReferenceImplementation()} for the assertion
+ * to be re-enabled once such an engine is available.</p>
+ */
+@Deployed
+public class AgentSmokeTest {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "agent-smoke.war")
+                .addClasses(GreetingAgent.class, GreetEvent.class,
+                        LargeLanguageModelStub.class,
+                        ExecutionTraceRecorder.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    Event<GreetEvent> events;
+
+    @Inject
+    LargeLanguageModelStub llm;
+
+    @Inject
+    ExecutionTraceRecorder trace;
+
+    @BeforeEach
+    public void setUp() {
+        llm.reset();
+        trace.reset();
+    }
+
+    @Assertion(id = "AGENTICAI-SMOKE-001",
+               section = "3.2 Agent Lifecycle",
+               strategy = "Agent Deployment -> CDI Event Trigger -> Trace records the @Trigger phase")
+    public void deploymentTriggersAgentObserver() {
+        events.fire(new GreetEvent("Jakarta AI"));
+
+        trace.assertOrder(Phase.TRIGGER);
+
+        ExecutionTraceRecorder.TraceEntry entry = trace.entries().get(0);
+        assertEquals("onGreet", entry.methodName(), "Trigger method name");
+        assertTrue(entry.args()[0] instanceof GreetEvent, "Trigger should receive the event");
+        assertEquals("Jakarta AI", ((GreetEvent) entry.args()[0]).getName(), "Event payload preserved");
+    }
+
+    /**
+     * Full-lifecycle assertion. Disabled until a Reference Implementation
+     * of the Agentic AI orchestration engine is available — plain CDI does
+     * not invoke {@code @Action} and {@code @Outcome} methods on its own.
+     */
+    @Disabled("Requires a Reference Implementation of the Agentic AI engine "
+            + "to dispatch @Action and @Outcome phases after the trigger.")
+    @Assertion(id = "AGENTICAI-SMOKE-002",
+               section = "3.2 Agent Lifecycle",
+               strategy = "Full lifecycle: @Trigger -> @Action -> @Outcome with LLM stub interaction")
+    public void fullLifecycleRequiresReferenceImplementation() {
+        llm.enqueueResponse("Hello from Stub!");
+
+        events.fire(new GreetEvent("Jakarta AI"));
+
+        trace.assertOrder(Phase.TRIGGER, Phase.ACTION, Phase.OUTCOME);
+
+        assertEquals(1, llm.recordedCalls().size(), "LLM should have been called once");
+        LargeLanguageModelStub.RecordedCall lastCall = llm.lastCall();
+        assertEquals("Greet {}", lastCall.prompt(), "Unexpected prompt template");
+        assertEquals("Jakarta AI", lastCall.params()[0], "Unexpected prompt parameter");
+        assertEquals(3, lastCall.overload(), "Should have used query(String, Object...) overload");
+
+        ExecutionTraceRecorder.TraceEntry outcomeEntry = trace.entries().stream()
+                .filter(e -> e.phase() == Phase.OUTCOME)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Hello from Stub!", outcomeEntry.args()[0], "Unexpected response in outcome");
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/integration/GreetEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/integration/GreetEvent.java
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.integration;
+
+/**
+ * Simple CDI event for the smoke test.
+ */
+public class GreetEvent {
+    private final String name;
+
+    public GreetEvent(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/integration/GreetingAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/integration/GreetingAgent.java
@@ -1,0 +1,59 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.integration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+/**
+ * Minimal agent for the smoke test.
+ *
+ * <p>Annotated with {@code @ApplicationScoped} so that the CDI container
+ * discovers the class as a bean and registers the {@code @Observes} method
+ * as an event observer. {@code @Agent} alone is not a CDI bean defining
+ * annotation.</p>
+ */
+@Agent
+@ApplicationScoped
+public class GreetingAgent {
+
+    @Inject
+    LargeLanguageModel llm;
+
+    @Inject
+    ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onGreet(@Observes GreetEvent event) {
+        trace.record(Phase.TRIGGER, "onGreet", event);
+    }
+
+    @Action
+    public String generateGreeting(GreetEvent event) {
+        trace.record(Phase.ACTION, "generateGreeting", event);
+        return llm.query("Greet {}", event.getName());
+    }
+
+    @Outcome
+    public void finished(String response) {
+        trace.record(Phase.OUTCOME, "finished", response);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/ActionAnnotationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/ActionAnnotationTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.lifecycle;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Action;
 import jakarta.ai.agent.Agent;
 
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Jakarta Agentic AI 1.0 specification requirements. The @Action annotation
  * marks methods that perform operations as part of the agent's workflow.
  */
+@Standalone
 public class ActionAnnotationTests {
 
     @Assertion(id = "AGENTICAI-ACTION-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/DecisionAnnotationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/DecisionAnnotationTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.lifecycle;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Agent;
 import jakarta.ai.agent.Decision;
 import jakarta.ai.agent.Result;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Jakarta Agentic AI 1.0 specification requirements. The @Decision annotation
  * marks methods that evaluate conditions and determine workflow continuation.
  */
+@Standalone
 public class DecisionAnnotationTests {
 
     @Assertion(id = "AGENTICAI-DECISION-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/HandleExceptionAnnotationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/HandleExceptionAnnotationTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.lifecycle;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Agent;
 import jakarta.ai.agent.HandleException;
 
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Jakarta Agentic AI 1.0 specification requirements. The @HandleException annotation
  * marks methods that handle errors occurring during workflow execution.
  */
+@Standalone
 public class HandleExceptionAnnotationTests {
 
     @Assertion(id = "AGENTICAI-HANDLEEXCEPTION-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/OutcomeAnnotationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/OutcomeAnnotationTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.lifecycle;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Agent;
 import jakarta.ai.agent.Outcome;
 
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * marks methods that produce the final result of a workflow and handle
  * completion logic.
  */
+@Standalone
 public class OutcomeAnnotationTests {
 
     @Assertion(id = "AGENTICAI-OUTCOME-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/TriggerAnnotationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/lifecycle/TriggerAnnotationTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.core.lifecycle;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Agent;
 import jakarta.ai.agent.Trigger;
 
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Jakarta Agentic AI 1.0 specification requirements. The @Trigger annotation
  * marks methods that initiate an agent workflow in response to external events.
  */
+@Standalone
 public class TriggerAnnotationTests {
 
     @Assertion(id = "AGENTICAI-TRIGGER-001",

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/anno/Assertion.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/anno/Assertion.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Target;
  * <h2>Example Usage</h2>
  * <pre>{@code
  * @Assertion(id = "AGENTICAI-001",
+ *            section = "3.1 Agent Metadata",
  *            strategy = "Verify @Agent annotation is retained at runtime")
  * public void testAgentAnnotationRetention() {
  *     // test implementation
@@ -47,6 +48,14 @@ public @interface Assertion {
      * @return the assertion ID
      */
     String id();
+
+    /**
+     * The specification section being verified, e.g. "3.2 Agent Lifecycle".
+     * Enables direct mapping between TCK failures and the specification.
+     *
+     * @return the specification section reference
+     */
+    String section() default "";
 
     /**
      * A description of the test strategy used to verify this assertion.

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/anno/Deployed.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/anno/Deployed.java
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.junit.anno;
+
+import ee.jakarta.tck.ai.agent.framework.junit.extensions.AssertionExtension;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta-annotation for TCK tests that require a full CDI container and
+ * the Jakarta Agentic AI runtime.
+ *
+ * <p>Deployed tests verify behavioral aspects of the specification
+ * within a managed environment.</p>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("deployed")
+@ExtendWith({ ArquillianExtension.class, AssertionExtension.class })
+public @interface Deployed {
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/anno/Standalone.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/anno/Standalone.java
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.junit.anno;
+
+import ee.jakarta.tck.ai.agent.framework.junit.extensions.AssertionExtension;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta-annotation for TCK tests that run in a standalone environment
+ * (outside of a Jakarta EE container).
+ *
+ * <p>Standalone tests typically focus on structural, signature, or
+ * metadata validation using reflection.</p>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("standalone")
+@Tag("core")
+@ExtendWith(AssertionExtension.class)
+public @interface Standalone {
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/AssertionExtension.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/AssertionExtension.java
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.junit.extensions;
+
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * JUnit 5 extension that logs information about specification assertions.
+ * It tracks the execution of methods annotated with {@link Assertion}.
+ */
+public class AssertionExtension implements TestWatcher, BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+    private static final Logger LOGGER = Logger.getLogger(AssertionExtension.class.getName());
+    private static final String NL = System.lineSeparator();
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        context.getTestMethod().ifPresent(method -> {
+            Assertion assertion = method.getAnnotation(Assertion.class);
+            if (assertion != null) {
+                LOGGER.info(() -> "Executing @Assertion #" + assertion.id() + " - " + method.getName());
+            }
+        });
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        context.getTestMethod().ifPresent(method -> {
+            Assertion assertion = method.getAnnotation(Assertion.class);
+            if (assertion != null) {
+                LOGGER.info(() -> "<<< End @Assertion #" + assertion.id() + " - " + method.getName());
+            }
+        });
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        logAssertionFailure(context, cause, "failed");
+    }
+
+    @Override
+    public void testAborted(ExtensionContext context, Throwable cause) {
+        logAssertionFailure(context, cause, "aborted");
+    }
+
+    @Override
+    public void testDisabled(ExtensionContext context, Optional<String> reason) {
+        context.getTestMethod().ifPresent(method -> {
+            Assertion assertion = method.getAnnotation(Assertion.class);
+            if (assertion != null) {
+                LOGGER.warning(() -> method.getName() + " disabled" + NL
+                        + " @Assertion.id: #" + assertion.id() + NL
+                        + " @Assertion.section: " + assertion.section() + NL
+                        + " @Assertion.strategy: " + assertion.strategy() + NL
+                        + " Reason: " + reason.orElse("N/A"));
+            }
+        });
+    }
+
+    private void logAssertionFailure(ExtensionContext context, Throwable cause, String status) {
+        context.getTestMethod().ifPresent(method -> {
+            Assertion assertion = method.getAnnotation(Assertion.class);
+            if (assertion != null) {
+                LOGGER.warning(() -> method.getName() + " " + status + NL
+                        + " @Assertion.id: #" + assertion.id() + NL
+                        + " @Assertion.section: " + assertion.section() + NL
+                        + " @Assertion.strategy: " + assertion.strategy() + NL
+                        + " Throwable.cause: " + (cause != null ? cause.getLocalizedMessage() : "N/A"));
+            }
+        });
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/signature/SignatureTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/signature/SignatureTests.java
@@ -13,6 +13,7 @@
 package ee.jakarta.tck.ai.agent.framework.signature;
 
 import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.*;
 
 import java.lang.reflect.Method;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * They ensure that all required types, methods, and annotations are present
  * with the correct signatures.
  */
+@Standalone
 public class SignatureTests {
 
     private static final String PACKAGE_NAME = "jakarta.ai.agent";

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
@@ -1,0 +1,154 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.stub;
+
+import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * CDI-enabled stub for {@link LargeLanguageModel} used in TCK behavioral tests.
+ * Provides a way to script responses and verify received prompts.
+ *
+ * <p>Responses and failures are queued and consumed in FIFO order.</p>
+ */
+@ApplicationScoped
+public class LargeLanguageModelStub implements LargeLanguageModel {
+
+    private final Queue<Object> scriptedResponses = new ArrayDeque<>();
+    private final Queue<RuntimeException> scriptedFailures = new ArrayDeque<>();
+    private final List<RecordedCall> calls = new CopyOnWriteArrayList<>();
+
+    /**
+     * Records a call to the model.
+     *
+     * @param prompt the prompt sent to the model
+     * @param resultType the expected result type, or null for default String queries
+     * @param params the parameters sent to the model
+     * @param overload the overload index (1-4)
+     * @param at the timestamp of the call
+     */
+    public record RecordedCall(String prompt, Class<?> resultType, Object[] params, int overload, Instant at) {}
+
+    /**
+     * Enqueues a response to be returned by the next call to any query method.
+     *
+     * @param response the response object
+     */
+    public void enqueueResponse(Object response) {
+        scriptedResponses.add(response);
+    }
+
+    /**
+     * Enqueues a failure to be thrown on the next call to any query method.
+     *
+     * @param e the exception to throw
+     */
+    public void failWith(RuntimeException e) {
+        this.scriptedFailures.add(e);
+    }
+
+    /**
+     * Resets the stub's state (scripted responses, failures, and recorded calls).
+     */
+    public void reset() {
+        scriptedResponses.clear();
+        scriptedFailures.clear();
+        calls.clear();
+    }
+
+    /**
+     * Returns a list of all recorded calls.
+     *
+     * @return the list of recorded calls
+     */
+    public List<RecordedCall> recordedCalls() {
+        return List.copyOf(calls);
+    }
+
+    /**
+     * Returns the last recorded call, or null if no calls were made.
+     *
+     * @return the last recorded call
+     */
+    public RecordedCall lastCall() {
+        return calls.isEmpty() ? null : calls.get(calls.size() - 1);
+    }
+
+    @Override
+    public String query(String prompt) {
+        return dispatch(prompt, null, 1);
+    }
+
+    @Override
+    public <T> T query(String prompt, Class<T> resultType) {
+        return dispatch(prompt, resultType, 2);
+    }
+
+    @Override
+    public String query(String prompt, Object... parameters) {
+        return dispatch(prompt, null, 3, parameters);
+    }
+
+    @Override
+    public <T> T query(String prompt, Class<T> resultType, Object... parameters) {
+        return dispatch(prompt, resultType, 4, parameters);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T dispatch(String prompt, Class<T> resultType, int overload, Object... params) {
+        if (prompt == null) {
+            throw new IllegalArgumentException("prompt is null");
+        }
+        calls.add(new RecordedCall(prompt, resultType, params, overload, Instant.now()));
+
+        RuntimeException scriptedFailure = scriptedFailures.poll();
+        if (scriptedFailure != null) {
+            throw scriptedFailure;
+        }
+
+        Object next = scriptedResponses.poll();
+        if (next == null) {
+            throw new IllegalStateException(
+                    "No scripted response queued for prompt: '" + prompt + "'. "
+                  + "Call enqueueResponse(...) before invoking the LLM in this test.");
+        }
+
+        if (resultType != null && !resultType.isInstance(next)) {
+            // For String result type, fall back to toString() conversion of the queued value.
+            if (resultType == String.class) {
+                return (T) next.toString();
+            }
+            // Spec contract: type conversion failures are reported as IllegalArgumentException
+            // (see LargeLanguageModel.query Javadoc).
+            throw new IllegalArgumentException(
+                    "Cannot convert queued response of type " + next.getClass().getName()
+                  + " to requested result type " + resultType.getName());
+        }
+
+        return (T) (resultType == null ? next.toString() : next);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> implClass) {
+        if (implClass != null && implClass.isInstance(this)) {
+            return implClass.cast(this);
+        }
+        throw new IllegalArgumentException("Cannot unwrap to " + implClass);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/trace/ExecutionTraceRecorder.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/trace/ExecutionTraceRecorder.java
@@ -1,0 +1,97 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.trace;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Internal utility for verifying the workflow execution flow.
+ * Captures the sequence of lifecycle method calls.
+ */
+@ApplicationScoped
+public class ExecutionTraceRecorder {
+
+    /**
+     * Represents the different phases of an agent's lifecycle.
+     */
+    public enum Phase {
+        TRIGGER, DECISION, ACTION, OUTCOME, HANDLE_EXCEPTION
+    }
+
+    /**
+     * Represents a single recorded trace entry.
+     *
+     * @param phase the lifecycle phase
+     * @param methodName the name of the method called
+     * @param args the arguments passed to the method
+     * @param at the timestamp of the recording
+     */
+    public record TraceEntry(Phase phase, String methodName, Object[] args, Instant at) {}
+
+    private final List<TraceEntry> entries = new CopyOnWriteArrayList<>();
+
+    /**
+     * Records an execution trace entry.
+     *
+     * @param phase the lifecycle phase
+     * @param methodName the name of the method
+     * @param args the method arguments
+     */
+    public void record(Phase phase, String methodName, Object... args) {
+        entries.add(new TraceEntry(phase, methodName, args, Instant.now()));
+    }
+
+    /**
+     * Returns all recorded trace entries.
+     *
+     * @return the list of trace entries
+     */
+    public List<TraceEntry> entries() {
+        return List.copyOf(entries);
+    }
+
+    /**
+     * Returns the sequence of recorded phases.
+     *
+     * @return the list of phases
+     */
+    public List<Phase> phases() {
+        return entries.stream().map(TraceEntry::phase).toList();
+    }
+
+    /**
+     * Resets the recorded traces.
+     */
+    public void reset() {
+        entries.clear();
+    }
+
+    /**
+     * Asserts that the recorded phases match the expected order.
+     *
+     * @param expected the expected sequence of phases
+     * @throws AssertionError if the order does not match
+     */
+    public void assertOrder(Phase... expected) {
+        List<Phase> actual = phases();
+        List<Phase> expectedList = List.of(expected);
+        if (!Objects.equals(actual, expectedList)) {
+            throw new AssertionError("Expected phase order " + expectedList + " but got " + actual);
+        }
+    }
+}

--- a/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStubTests.java
+++ b/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStubTests.java
@@ -1,0 +1,117 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.stub;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link LargeLanguageModelStub}.
+ *
+ * <p>These exercise the TCK's own infrastructure, not the specification.
+ * They are tagged {@code internal} so they do not inflate spec assertion
+ * counts when running with {@code -Dgroups=standalone}.</p>
+ */
+@Tag("internal")
+public class LargeLanguageModelStubTests {
+
+    private LargeLanguageModelStub stub;
+
+    @BeforeEach
+    void setUp() {
+        stub = new LargeLanguageModelStub();
+    }
+
+    @Test
+    void testEnqueueResponse() {
+        stub.enqueueResponse("Hello");
+        assertEquals("Hello", stub.query("test"));
+    }
+
+    @Test
+    void testMultipleResponses() {
+        stub.enqueueResponse("First");
+        stub.enqueueResponse("Second");
+        assertEquals("First", stub.query("1"));
+        assertEquals("Second", stub.query("2"));
+    }
+
+    @Test
+    void testNoResponseQueuedFailsLoudly() {
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> stub.query("test"));
+        assertTrue(e.getMessage().contains("test"), "Message should reference the offending prompt");
+    }
+
+    @Test
+    void testTypeMismatchThrowsIllegalArgumentException() {
+        stub.enqueueResponse(42);
+        assertThrows(IllegalArgumentException.class, () -> stub.query("test", java.util.Date.class),
+                "Spec contract: type conversion failures must be IllegalArgumentException");
+    }
+
+    @Test
+    void testMultipleFailures() {
+        stub.failWith(new RuntimeException("Error 1"));
+        stub.failWith(new RuntimeException("Error 2"));
+        stub.enqueueResponse("ok");
+
+        RuntimeException e1 = assertThrows(RuntimeException.class, () -> stub.query("test 1"));
+        assertEquals("Error 1", e1.getMessage());
+
+        RuntimeException e2 = assertThrows(RuntimeException.class, () -> stub.query("test 2"));
+        assertEquals("Error 2", e2.getMessage());
+
+        assertEquals("ok", stub.query("test 3"), "Should consume queued response after failures are drained");
+    }
+
+    @Test
+    void testRecordedCalls() {
+        stub.enqueueResponse("r1");
+        stub.enqueueResponse(7);
+        stub.enqueueResponse("r3");
+        stub.enqueueResponse("r4");
+
+        stub.query("Hello 1");
+        stub.query("Hello 2", Integer.class);
+        stub.query("Hello 3", "p1");
+        stub.query("Hello 4", String.class, "p2");
+        
+        List<LargeLanguageModelStub.RecordedCall> calls = stub.recordedCalls();
+        assertEquals(4, calls.size());
+        
+        assertEquals(1, calls.get(0).overload());
+        assertNull(calls.get(0).resultType());
+        
+        assertEquals(2, calls.get(1).overload());
+        assertEquals(Integer.class, calls.get(1).resultType());
+        
+        assertEquals(3, calls.get(2).overload());
+        assertNull(calls.get(2).resultType());
+        assertArrayEquals(new Object[]{"p1"}, calls.get(2).params());
+        
+        assertEquals(4, calls.get(3).overload());
+        assertEquals(String.class, calls.get(3).resultType());
+        assertArrayEquals(new Object[]{"p2"}, calls.get(3).params());
+    }
+
+    @Test
+    void testUnwrap() {
+        assertSame(stub, stub.unwrap(LargeLanguageModelStub.class));
+        assertThrows(IllegalArgumentException.class, () -> stub.unwrap(String.class));
+    }
+}

--- a/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/trace/ExecutionTraceRecorderTests.java
+++ b/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/trace/ExecutionTraceRecorderTests.java
@@ -1,0 +1,86 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.trace;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ExecutionTraceRecorder}.
+ *
+ * <p>These exercise the TCK's own infrastructure, not the specification.
+ * They are tagged {@code internal} so they do not inflate spec assertion
+ * counts when running with {@code -Dgroups=standalone}.</p>
+ */
+@Tag("internal")
+public class ExecutionTraceRecorderTests {
+
+    private ExecutionTraceRecorder recorder;
+
+    @BeforeEach
+    void setUp() {
+        recorder = new ExecutionTraceRecorder();
+    }
+
+    @Test
+    void testRecordAndGet() {
+        recorder.record(ExecutionTraceRecorder.Phase.TRIGGER, "onEvent", "arg1");
+        recorder.record(ExecutionTraceRecorder.Phase.ACTION, "doWork");
+
+        List<ExecutionTraceRecorder.TraceEntry> entries = recorder.entries();
+        assertEquals(2, entries.size());
+        assertEquals(ExecutionTraceRecorder.Phase.TRIGGER, entries.get(0).phase());
+        assertEquals("onEvent", entries.get(0).methodName());
+        assertArrayEquals(new Object[]{"arg1"}, entries.get(0).args());
+
+        assertEquals(ExecutionTraceRecorder.Phase.ACTION, entries.get(1).phase());
+        assertEquals("doWork", entries.get(1).methodName());
+    }
+
+    @Test
+    void testAssertOrderSuccess() {
+        recorder.record(ExecutionTraceRecorder.Phase.TRIGGER, "m1");
+        recorder.record(ExecutionTraceRecorder.Phase.ACTION, "m2");
+        recorder.record(ExecutionTraceRecorder.Phase.OUTCOME, "m3");
+
+        assertDoesNotThrow(() -> recorder.assertOrder(
+                ExecutionTraceRecorder.Phase.TRIGGER,
+                ExecutionTraceRecorder.Phase.ACTION,
+                ExecutionTraceRecorder.Phase.OUTCOME
+        ));
+    }
+
+    @Test
+    void testAssertOrderFailure() {
+        recorder.record(ExecutionTraceRecorder.Phase.TRIGGER, "m1");
+        recorder.record(ExecutionTraceRecorder.Phase.OUTCOME, "m3");
+
+        assertThrows(AssertionError.class, () -> recorder.assertOrder(
+                ExecutionTraceRecorder.Phase.TRIGGER,
+                ExecutionTraceRecorder.Phase.ACTION,
+                ExecutionTraceRecorder.Phase.OUTCOME
+        ));
+    }
+
+    @Test
+    void testReset() {
+        recorder.record(ExecutionTraceRecorder.Phase.TRIGGER, "m1");
+        recorder.reset();
+        assertTrue(recorder.entries().isEmpty());
+    }
+}

--- a/tck/src/test/resources/arquillian.xml
+++ b/tck/src/test/resources/arquillian.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://www.jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.jboss.org/schema/arquillian http://www.jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <!-- Default configuration -->
+</arquillian>


### PR DESCRIPTION
Moving the TCK beyond signature/reflection checks so we can start covering real behavioral semantics. The patterns are borrowed from Jakarta Data and Batch: everything new lives in `tck/` and never leaves the public artifact.

### What's in

**`@Assertion.section`** — optional field on the existing annotation. Lets a failure point straight at a spec section, e.g. `section = "3.2 Agent Lifecycle"`. The new `AssertionExtension` (JUnit 5) logs id/section/strategy on start, end, fail, abort and disable so the TCK reports tell you exactly where in the spec you broke.

**`@Standalone` and `@Deployed`** — meta-annotations that swap the test profile. `@Standalone` keeps reflection-based tests running outside a container; `@Deployed` plugs in `ArquillianExtension` for behavioral tests that need a CDI runtime.

**`LargeLanguageModelStub`** (`@ApplicationScoped`) — FIFO queues for responses and failures, per-overload call recording, spec-aligned `unwrap()`. Two design choices worth flagging:
- Type-conversion failures raise `IllegalArgumentException`, matching the `LargeLanguageModel.query` Javadoc.
- A `query` with no scripted response raises `IllegalStateException` instead of returning empty/null. Noisier when you forget `enqueueResponse(...)`, but you find the bug at the call site.

**`ExecutionTraceRecorder`** (`@ApplicationScoped`) — captures `(phase, methodName, args, timestamp)` per call, with an `assertOrder(...)` helper. Gives us a deterministic way to verify orchestration order while `WorkflowContext` is deferred to v2.

### Migration

Nine existing structural test classes (75 reflection-based assertions across `core/agent`, `core/lifecycle`, `core/cdi`, `framework/signature`) now carry `@Standalone`. No regressions.

### Smoke test

`AgentSmokeTest` (`@Deployed`) boots a Weld-embedded archive containing a small `GreetingAgent` and verifies the trigger phase records correctly with the event payload preserved.

`GreetingAgent` is `@ApplicationScoped` on top of `@Agent`: with CDI 4.x's `bean-discovery-mode=annotated` (the default for an empty `beans.xml`), `@Agent` alone is not a bean defining annotation, so without the scope nothing gets discovered and the `@Observes` trigger never fires.

The full-lifecycle assertion (`@Trigger -> @Action -> @Outcome` plus LLM stub interaction) ships as a `@Disabled` companion. Plain CDI can't dispatch `@Action` and `@Outcome` on its own; we'll flip it on once the RI engine lands.

### Hygiene

- Internal infrastructure tests (`LargeLanguageModelStubTests`, `ExecutionTraceRecorderTests`) live in `src/test/java` with `@Tag("internal")` so they don't inflate spec assertion counts when running `-Dgroups=standalone`.
- `arquillian.xml` lives under `src/test/resources` so it stays out of the public TCK jar.
- New `weld-embedded` Maven profile pulls in `arquillian-weld-embedded` and `weld-core-impl` for local container runs.

### How to run

- `mvn -pl tck verify` — 75 standalone assertions
- `mvn -pl tck verify -Pweld-embedded` — 77 tests, 0 failures, 1 skipped (the disabled full-lifecycle assertion)
- Surefire picks up the 11 internal tests (stub 7, recorder 4)

The `api/` module is untouched.