### PR TITLE
FISH-13596 Add behavioral TCK tests for agent discovery, CDI integration and lifecycle scopes

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -193,8 +193,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>3.5.2</version>
-                        <configuration>
-                            <excludedGroups/>
+                        <configuration combine.self="override">
+                            <testSourceDirectory>src/main/java</testSourceDirectory>
+                            <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
+                            <includes>
+                                <include>**/*Tests.java</include>
+                                <include>**/*Test.java</include>
+                            </includes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/CdiIntegrationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/CdiIntegrationTests.java
@@ -1,0 +1,261 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior;
+
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.AgentInterceptorBinding;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.AgentInterceptorImpl;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ConstructorInjectedAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ConstructorInjectedEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.InnerAgentContainer;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.InnerAgentEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.InterceptedAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.InterceptedEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ResolutionCdiBean;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ResolutionOrderAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ResolutionOrderEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.SingletonCdiAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.SingletonCdiEvent;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Deployed;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.TraceEntry;
+import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Deployed
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CdiIntegrationTests {
+
+    private static final String NO_RI =
+            "Requires a Reference Implementation of the Agentic AI engine "
+          + "to dispatch @Decision/@Action/@Outcome phases.";
+
+    // Interceptor enabled here (NOT via @Priority — see constraint #5 in steps.md).
+    private static final String BEANS_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                       https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+                   version="4.0">
+                <interceptors>
+                    <class>ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.AgentInterceptorImpl</class>
+                </interceptors>
+            </beans>
+            """;
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "cdiintegration.war")
+                .addClasses(
+                        SingletonCdiAgent.class,         SingletonCdiEvent.class,
+                        ConstructorInjectedAgent.class,  ConstructorInjectedEvent.class,
+                        InterceptedAgent.class,          InterceptedEvent.class,
+                        AgentInterceptorBinding.class,   AgentInterceptorImpl.class,
+                        ResolutionOrderAgent.class,      ResolutionOrderEvent.class,
+                        ResolutionCdiBean.class,
+                        InnerAgentContainer.class,       InnerAgentContainer.InnerAgent.class,
+                        InnerAgentEvent.class
+                )
+                .addAsWebInfResource(new StringAsset(BEANS_XML), "beans.xml");
+    }
+
+    @Inject Event<SingletonCdiEvent>        singletonEvents;
+    @Inject Event<ConstructorInjectedEvent> constructorInjectedEvents;
+    @Inject Event<InterceptedEvent>         interceptedEvents;
+    @Inject Event<ResolutionOrderEvent>     resolutionOrderEvents;
+    @Inject Event<InnerAgentEvent>          innerAgentEvents;
+    @Inject ExecutionTraceRecorder          trace;
+    @Inject SingletonCdiAgent               singletonAgent;
+
+    // -------------------------------------------------------------------------
+    // CDI-only tests (no RI required)
+    // -------------------------------------------------------------------------
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-002",
+               section = "Architecture, Convention over Configuration",
+               strategy = "A static nested class annotated @Agent @ApplicationScoped is discovered as a CDI "
+                        + "managed bean and its @Trigger observer fires when the triggering event is fired")
+    public void staticInnerAgentIsDiscoveredAsCdiBean() {
+        trace.reset();
+        innerAgentEvents.fire(new InnerAgentEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-002",
+               section = "Architecture, Convention over Configuration",
+               strategy = "An @Agent bean using @Inject constructor injection (no no-args constructor) is a valid "
+                        + "CDI managed bean; the @Trigger fires, proving the container created it via its constructor")
+    public void constructorInjectedAgentIsDiscoveredAndManaged() {
+        trace.reset();
+        constructorInjectedEvents.fire(new ConstructorInjectedEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-002",
+               section = "Architecture, Convention over Configuration",
+               strategy = "An @ApplicationScoped @Agent is a first-class CDI bean: the container injects a "
+                        + "client proxy (a generated subclass), not the raw instance. Proven by the injected "
+                        + "reference being an instance of the agent type but having a different runtime class")
+    public void agentIsInjectedAsCdiProxy() {
+        // Normal-scoped beans are always client-proxied per the CDI spec, so the proxy
+        // is a subclass with a different Class object. Portable across CDI implementations.
+        assertThat(singletonAgent).isInstanceOf(SingletonCdiAgent.class);
+        assertThat(singletonAgent.getClass()).isNotEqualTo(SingletonCdiAgent.class);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-003-PRECONDITION",
+               section = "CDI Integration, Lifecycle",
+               strategy = "SingletonCdiAgent @Trigger fires via CDI; confirms the bean is instantiated and managed")
+    public void singletonAgentTriggerObserved() {
+        trace.reset();
+        singletonEvents.fire(new SingletonCdiEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-003",
+               section = "CDI Integration, Lifecycle",
+               strategy = "@PostConstruct is invoked exactly once for an @ApplicationScoped @Agent regardless of "
+                        + "how many workflow events are fired; the static instance counter stays 1")
+    public void applicationScopedAgentPostConstructCalledOnce() {
+        trace.reset();
+        singletonEvents.fire(new SingletonCdiEvent("first"));
+        singletonEvents.fire(new SingletonCdiEvent("second"));
+        assertThat(SingletonCdiAgent.getInstanceCount()).isEqualTo(1);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-004",
+               section = "CDI Integration, Scopes",
+               strategy = "An @ApplicationScoped @Agent reuses the same bean instance across sequential workflow "
+                        + "events — both @Trigger invocations record the same instanceId in the trace")
+    public void applicationScopedAgentSharesInstanceAcrossWorkflows() {
+        trace.reset();
+        singletonEvents.fire(new SingletonCdiEvent("first"));
+        int id1 = (int) trace.entries().get(0).args()[1];
+
+        trace.reset();
+        singletonEvents.fire(new SingletonCdiEvent("second"));
+        int id2 = (int) trace.entries().get(0).args()[1];
+
+        assertThat(id1).isEqualTo(id2);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-006-PRECONDITION",
+               section = "CDI Integration, Interceptors",
+               strategy = "InterceptedAgent @Trigger fires via CDI; confirms the agent and its enabled interceptor "
+                        + "deploy without error")
+    public void interceptedAgentTriggerObserved() {
+        trace.reset();
+        interceptedEvents.fire(new InterceptedEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-005-PRECONDITION",
+               section = "Workflow Orchestration, Parameter Injection",
+               strategy = "ResolutionOrderAgent @Trigger fires via CDI; confirms the agent and its CDI-bean "
+                        + "collaborator (ResolutionCdiBean) deploy without resolution errors")
+    public void resolutionOrderAgentTriggerObserved() {
+        trace.reset();
+        resolutionOrderEvents.fire(new ResolutionOrderEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    // -------------------------------------------------------------------------
+    // RI-required tests
+    // -------------------------------------------------------------------------
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-004",
+               section = "CDI Integration, Scopes",
+               strategy = "An @ApplicationScoped @Agent uses the same bean instance across all phases of a "
+                        + "workflow — @Trigger, @Action, @Outcome all record the same instanceId")
+    public void applicationScopedAgentUseSameInstanceAcrossAllPhases() {
+        trace.reset();
+        singletonEvents.fire(new SingletonCdiEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.ACTION, Phase.OUTCOME);
+        int triggerId = (int) trace.entries().get(0).args()[1];
+        int actionId  = (int) trace.entries().get(1).args()[1];
+        int outcomeId = (int) trace.entries().get(2).args()[1];
+        assertThat(actionId).isEqualTo(triggerId);
+        assertThat(outcomeId).isEqualTo(triggerId);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-005",
+               section = "Workflow Orchestration, Parameter Injection",
+               strategy = "The RI resolves method parameters in priority order: (1) triggering event, (3) "
+                        + "LargeLanguageModel, (4) CDI beans — ResolutionOrderAgent @Action args are "
+                        + "[0]=event, [1]=LLM, [2]=ResolutionCdiBean")
+    public void parameterResolutionFollowsDefinedPriority() {
+        trace.reset();
+        resolutionOrderEvents.fire(new ResolutionOrderEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.DECISION, Phase.ACTION, Phase.OUTCOME);
+        var actionEntry = trace.entries().stream()
+                .filter(e -> e.phase() == Phase.ACTION && e.methodName().equals("process"))
+                .findFirst().orElseThrow();
+        assertThat(actionEntry.args()[0]).isInstanceOf(ResolutionOrderEvent.class);
+        assertThat(actionEntry.args()[1]).isInstanceOf(LargeLanguageModel.class);
+        assertThat(actionEntry.args()[2]).isInstanceOf(ResolutionCdiBean.class);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-006",
+               section = "CDI Integration, Interceptors",
+               strategy = "A CDI interceptor bound via a custom @InterceptorBinding executes before and after the "
+                        + "method body for EVERY business-method phase the RI dispatches through the CDI proxy — "
+                        + "verified by binding the interceptor to both @Action (process) and @Outcome (finish) and "
+                        + "asserting the interceptor wraps each. Asserts on method-name order because the interceptor "
+                        + "marker uses a fixed phase label")
+    public void cdiInterceptorExecutesAroundActionAndOutcome() {
+        trace.reset();
+        interceptedEvents.fire(new InterceptedEvent("test"));
+        List<String> names = trace.entries().stream().map(TraceEntry::methodName).toList();
+        assertThat(names).containsExactly(
+                "onEvent",
+                "interceptorBefore", "process",  "interceptorAfter",
+                "interceptorBefore", "finish",   "interceptorAfter");
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-007",
+               section = "Workflow Orchestration",
+               strategy = "The triggering event object is available as a method parameter in @Decision, @Action, "
+                        + "and @Outcome — all three downstream phases receive it as args()[0]")
+    public void triggeringEventIsAvailableInAllDownstreamPhases() {
+        trace.reset();
+        resolutionOrderEvents.fire(new ResolutionOrderEvent("event-payload"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.DECISION, Phase.ACTION, Phase.OUTCOME);
+        trace.entries().stream()
+                .filter(e -> e.phase() != Phase.TRIGGER)
+                .forEach(e -> assertThat(e.args()[0])
+                        .isInstanceOf(ResolutionOrderEvent.class)
+                        .extracting(o -> ((ResolutionOrderEvent) o).payload())
+                        .isEqualTo("event-payload"));
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/OrchestrationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/OrchestrationTests.java
@@ -1,0 +1,259 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior;
+
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.AnchoredAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.AnchoredEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.BranchingAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.BranchingEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.IntermixedAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.IntermixedEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.LinearAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.LinearEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.MinimalistAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.MinimalistEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.OutcomeOnlyAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration.OutcomeOnlyEvent;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Deployed;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.TraceEntry;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Deployed
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OrchestrationTests {
+
+    private static final String NO_RI =
+            "Requires a Reference Implementation of the Agentic AI engine "
+          + "to dispatch @Decision/@Action/@Outcome phases.";
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "orchestration.war")
+                .addClasses(
+                        MinimalistAgent.class,   MinimalistEvent.class,
+                        LinearAgent.class,       LinearEvent.class,
+                        IntermixedAgent.class,   IntermixedEvent.class,
+                        BranchingAgent.class,    BranchingEvent.class,
+                        OutcomeOnlyAgent.class,  OutcomeOnlyEvent.class,
+                        AnchoredAgent.class,     AnchoredEvent.class
+                )
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject Event<MinimalistEvent>  minimalistEvents;
+    @Inject Event<LinearEvent>      linearEvents;
+    @Inject Event<IntermixedEvent>  intermixedEvents;
+    @Inject Event<BranchingEvent>   branchingEvents;
+    @Inject Event<OutcomeOnlyEvent> outcomeOnlyEvents;
+    @Inject Event<AnchoredEvent>    anchoredEvents;
+    @Inject ExecutionTraceRecorder  trace;
+    @Inject BranchingAgent          branchingAgent;
+
+    // -------------------------------------------------------------------------
+    // CDI-only tests (no RI required)
+    // -------------------------------------------------------------------------
+
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-006",
+               section = "Workflow Composition Patterns",
+               strategy = "Minimalist pattern: an agent with @Trigger only is a valid complete workflow; "
+                        + "firing the event drives the trigger via CDI without any engine")
+    public void minimalistWorkflowCompletesWithTriggerOnly() {
+        trace.reset();
+        minimalistEvents.fire(new MinimalistEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-002-PRECONDITION",
+               section = "Workflow Composition Patterns",
+               strategy = "LinearAgent @Trigger is observed by CDI without a runtime engine")
+    public void linearAgentTriggerObserved() {
+        trace.reset();
+        linearEvents.fire(new LinearEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-004-PRECONDITION",
+               section = "Workflow Composition Patterns",
+               strategy = "IntermixedAgent @Trigger is observed by CDI without a runtime engine")
+    public void intermixedAgentTriggerObserved() {
+        trace.reset();
+        intermixedEvents.fire(new IntermixedEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-005-PRECONDITION",
+               section = "Workflow Termination",
+               strategy = "BranchingAgent @Trigger is observed by CDI without a runtime engine "
+                        + "regardless of which decision is configured as the termination point")
+    public void branchingAgentTriggerObserved() {
+        trace.reset();
+        branchingAgent.setTerminateAt(BranchingAgent.TerminationPoint.FIRST_DECISION);
+        branchingEvents.fire(new BranchingEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-006-EVALUATIVE-PRECONDITION",
+               section = "Workflow Composition Patterns",
+               strategy = "OutcomeOnlyAgent (Evaluative pattern) @Trigger is observed by CDI without a runtime engine")
+    public void outcomeOnlyAgentTriggerObserved() {
+        trace.reset();
+        outcomeOnlyEvents.fire(new OutcomeOnlyEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-001-PRECONDITION",
+               section = "Workflow Composition Patterns",
+               strategy = "AnchoredAgent @Trigger is observed by CDI even when declared at the bottom of the source file")
+    public void anchoredAgentTriggerObserved() {
+        trace.reset();
+        anchoredEvents.fire(new AnchoredEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER);
+    }
+
+    // -------------------------------------------------------------------------
+    // RI-required tests — core orchestration rules
+    // -------------------------------------------------------------------------
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-001",
+               section = "Workflow Composition Patterns",
+               strategy = "@Trigger is always the first phase invoked even when declared at the bottom "
+                        + "of the source file — verified via AnchoredAgent where @Trigger is the LAST method declared")
+    public void triggerIsAlwaysFirstPhaseRegardlessOfPosition() {
+        trace.reset();
+        anchoredEvents.fire(new AnchoredEvent("test"));
+        assertThat(trace.phases()).startsWith(Phase.TRIGGER);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-002",
+               section = "@Action / Cardinality and Order",
+               strategy = "@Decision and @Action execute in source-file declaration order; AnchoredAgent declares "
+                        + "@Action BEFORE @Decision so an order-correct engine must invoke act() before decide()")
+    public void methodsExecuteInDeclarationOrder() {
+        trace.reset();
+        anchoredEvents.fire(new AnchoredEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.ACTION, Phase.DECISION, Phase.OUTCOME);
+        List<String> names = trace.entries().stream().map(TraceEntry::methodName).toList();
+        assertThat(names).containsExactly("onEvent", "act", "decide", "finish");
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-003",
+               section = "Workflow Composition Patterns",
+               strategy = "@Outcome is always the last phase invoked in a successful workflow even when declared "
+                        + "at the top of the source file — verified via AnchoredAgent where @Outcome is the FIRST method declared")
+    public void outcomeIsAlwaysLastPhaseRegardlessOfPosition() {
+        trace.reset();
+        anchoredEvents.fire(new AnchoredEvent("test"));
+        assertThat(trace.phases()).endsWith(Phase.OUTCOME);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-004",
+               section = "Workflow Composition Patterns",
+               strategy = "Multiple alternating @Decision and @Action phases all execute in declaration order")
+    public void intermixedDecisionAndActionPhasesSupported() {
+        trace.reset();
+        intermixedEvents.fire(new IntermixedEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.DECISION, Phase.ACTION,
+                                 Phase.DECISION, Phase.ACTION, Phase.OUTCOME);
+        List<String> names = trace.entries().stream().map(TraceEntry::methodName).toList();
+        assertThat(names).containsExactly(
+                "onEvent", "firstDecide", "firstAction", "secondDecide", "secondAction", "finish");
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-005",
+               section = "Workflow Termination",
+               strategy = "false from the FIRST @Decision in a chain immediately prevents ALL subsequent phases "
+                        + "including the trailing @Outcome anchor")
+    public void terminationAtFirstDecisionHaltsEntirePipeline() {
+        trace.reset();
+        branchingAgent.setTerminateAt(BranchingAgent.TerminationPoint.FIRST_DECISION);
+        branchingEvents.fire(new BranchingEvent("test"));
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER, Phase.DECISION);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-005",
+               section = "Workflow Termination",
+               strategy = "false from a MID-CHAIN @Decision (after an upstream decision proceeded) prevents the "
+                        + "remaining @Action and the trailing @Outcome anchor — the engine must keep checking termination "
+                        + "across the whole chain, not just at the first decision")
+    public void terminationAtSecondDecisionHaltsRemainingPipeline() {
+        trace.reset();
+        branchingAgent.setTerminateAt(BranchingAgent.TerminationPoint.SECOND_DECISION);
+        branchingEvents.fire(new BranchingEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.DECISION, Phase.ACTION, Phase.DECISION);
+    }
+
+    // -------------------------------------------------------------------------
+    // RI-required tests — composition patterns (BHV-006)
+    // -------------------------------------------------------------------------
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-006",
+               section = "Workflow Composition Patterns",
+               strategy = "Linear pattern: multiple @Action phases execute sequentially without any @Decision")
+    public void linearPatternSupported() {
+        trace.reset();
+        linearEvents.fire(new LinearEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.ACTION, Phase.ACTION, Phase.ACTION, Phase.OUTCOME);
+        List<String> names = trace.entries().stream().map(TraceEntry::methodName).toList();
+        assertThat(names).containsExactly(
+                "onEvent", "firstAction", "secondAction", "thirdAction", "finish");
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-006",
+               section = "Workflow Composition Patterns",
+               strategy = "Evaluative pattern: @Decision proceeds directly to @Outcome when no @Action is declared")
+    public void evaluativePatternSupported() {
+        trace.reset();
+        outcomeOnlyEvents.fire(new OutcomeOnlyEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.DECISION, Phase.OUTCOME);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-ORCHESTRATION-BHV-006",
+               section = "Workflow Composition Patterns",
+               strategy = "Intermixed pattern: alternating @Decision/@Action chain executes in declaration order through @Outcome")
+    public void intermixedPatternSupported() {
+        trace.reset();
+        intermixedEvents.fire(new IntermixedEvent("test"));
+        assertThat(trace.phases())
+                .containsExactly(Phase.TRIGGER, Phase.DECISION, Phase.ACTION,
+                                 Phase.DECISION, Phase.ACTION, Phase.OUTCOME);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/WorkflowScopeLifecycleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/WorkflowScopeLifecycleTests.java
@@ -1,0 +1,163 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior;
+
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.LifecycleCallbackRecorder;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.LifecycleSpyAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.LifecycleSpyEvent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ScopeDefaultAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.cdi.ScopeDefaultEvent;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Deployed;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Deployed
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class WorkflowScopeLifecycleTests {
+
+    private static final String NO_RI =
+            "Requires a Reference Implementation of the Agentic AI engine "
+          + "to activate the @WorkflowScoped context and dispatch phases.";
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "workflowscopelifecycle.war")
+                .addClasses(
+                        LifecycleSpyAgent.class,        LifecycleSpyEvent.class,
+                        ScopeDefaultAgent.class,        ScopeDefaultEvent.class,
+                        LifecycleCallbackRecorder.class
+                )
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject Event<LifecycleSpyEvent>  lifecycleSpyEvents;
+    @Inject Event<ScopeDefaultEvent>  scopeDefaultEvents;
+    @Inject ExecutionTraceRecorder    trace;
+    @Inject LifecycleCallbackRecorder lifecycleRecorder;
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-001",
+               section = "Agent Lifecycle, @Agent",
+               strategy = "An @Agent with no explicit scope behaves as @WorkflowScoped: two independent "
+                        + "workflow executions yield two distinct bean instances. Verified via ScopeDefaultAgent "
+                        + "(no scope) recording a unique instanceId per workflow. NOTE: sequential events used as a "
+                        + "v1 proxy for concurrent workflows.")
+    public void defaultScopeProducesDistinctInstancePerWorkflow() {
+        lifecycleRecorder.reset();
+        trace.reset();
+        // RI fires ScopeDefaultEvent twice (two independent workflows).
+        List<String> ids = lifecycleRecorder.getInstanceIds();
+        assertThat(ids).hasSize(2);
+        assertThat(ids.get(0)).isNotEqualTo(ids.get(1));
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-002",
+               section = "Architecture, Convention over Configuration",
+               strategy = "When @Agent.name() is empty, the RI derives the name as the simple class name with "
+                        + "the first letter lowercased. ScopeDefaultAgent must be resolvable by the EL/bean name "
+                        + "\"scopeDefaultAgent\" via BeanManager.getBeans(String). Depends on the RI registering "
+                        + "agents under their derived name; update once that registry API is specified.")
+    public void agentDefaultNamingFollowsCamelCase() {
+        // Pseudocode for when the RI is available:
+        //   assertThat(beanManager.getBeans("scopeDefaultAgent")).hasSize(1);
+        // Kept disabled and intentionally not asserting a placeholder truth.
+        assertThat(ScopeDefaultAgent.class.getSimpleName()).isEqualTo("ScopeDefaultAgent");
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-002",
+               section = "Architecture, Convention over Configuration",
+               strategy = "An explicit @Agent(name = \"lifecycleSpy\") overrides the derived default; the RI must "
+                        + "register the bean under that name, resolvable via BeanManager.getBeans(\"lifecycleSpy\"). "
+                        + "Depends on the RI's name-registration API; update once specified.")
+    public void customAgentNameIsResolvableViaBeanManager() {
+        // Pseudocode for when the RI is available:
+        //   assertThat(beanManager.getBeans("lifecycleSpy")).hasSize(1);
+        // LifecycleSpyAgent declares @Agent(name = "lifecycleSpy"); assert the source-of-truth in the interim.
+        assertThat(LifecycleSpyAgent.class.getAnnotation(jakarta.ai.agent.Agent.class).name())
+                .isEqualTo("lifecycleSpy");
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-003",
+               section = "CDI Integration, Lifecycle",
+               strategy = "@PostConstruct is invoked exactly once per @WorkflowScoped workflow execution — "
+                        + "LifecycleCallbackRecorder counts one @PostConstruct call after a single workflow")
+    public void workflowScopedAgentPostConstructCalledOnce() {
+        lifecycleRecorder.reset();
+        trace.reset();
+        // RI fires LifecycleSpyEvent and drives the full workflow.
+        assertThat(lifecycleRecorder.getPostConstructCount()).isEqualTo(1);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-003",
+               section = "CDI Integration, Lifecycle",
+               strategy = "@PreDestroy is invoked exactly once after the @WorkflowScoped context is destroyed "
+                        + "(workflow completes through @Outcome) — LifecycleCallbackRecorder counts one call")
+    public void workflowScopedAgentPreDestroyCalledAfterWorkflow() {
+        lifecycleRecorder.reset();
+        trace.reset();
+        assertThat(trace.phases()).endsWith(Phase.OUTCOME);
+        assertThat(lifecycleRecorder.getPreDestroyCount()).isEqualTo(1);
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-003",
+               section = "CDI Integration, Lifecycle",
+               strategy = "@PreDestroy is invoked exactly once even when the workflow FAILS (the issue requires "
+                        + "cleanup 'after the workflow completes or fails'). LifecycleSpyAgent.setFailInAction(true) "
+                        + "makes @Action throw; the RI must still tear down the @WorkflowScoped context and the "
+                        + "workflow must not reach @Outcome")
+    public void workflowScopedAgentPreDestroyCalledAfterFailure() {
+        lifecycleRecorder.reset();
+        trace.reset();
+        LifecycleSpyAgent.setFailInAction(true);
+        try {
+            // RI fires LifecycleSpyEvent; @Action throws and the workflow terminates.
+            assertThat(trace.phases()).doesNotContain(Phase.OUTCOME);
+            assertThat(lifecycleRecorder.getPreDestroyCount()).isEqualTo(1);
+        } finally {
+            LifecycleSpyAgent.setFailInAction(false);
+        }
+    }
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-CDI-BHV-004",
+               section = "CDI Integration, Scopes",
+               strategy = "@WorkflowScoped creates a distinct bean instance per workflow execution — two "
+                        + "sequential events yield two different instanceIds (v1 proxy for concurrent workflows)")
+    public void workflowScopedAgentHasUniqueInstancePerWorkflow() {
+        lifecycleRecorder.reset();
+        trace.reset();
+        // RI fires LifecycleSpyEvent twice (two independent workflows).
+        List<String> ids = lifecycleRecorder.getInstanceIds();
+        assertThat(ids).hasSize(2);
+        assertThat(ids.get(0)).isNotEqualTo(ids.get(1));
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/AgentInterceptorBinding.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/AgentInterceptorBinding.java
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import jakarta.interceptor.InterceptorBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface AgentInterceptorBinding {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/AgentInterceptorImpl.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/AgentInterceptorImpl.java
@@ -1,0 +1,38 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+// NOTE: NO @Priority here — the interceptor is enabled via the <interceptors>
+// element of beans.xml (see CdiIntegrationTests deployment). Enabling it through
+// both @Priority and beans.xml would enable it twice (non-portable; Weld may reject).
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@AgentInterceptorBinding
+@Interceptor
+public class AgentInterceptorImpl {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        trace.record(Phase.ACTION, "interceptorBefore", ctx.getMethod().getName());
+        Object result = ctx.proceed();
+        trace.record(Phase.ACTION, "interceptorAfter", ctx.getMethod().getName());
+        return result;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ConstructorInjectedAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ConstructorInjectedAgent.java
@@ -1,0 +1,38 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class ConstructorInjectedAgent {
+
+    private final ExecutionTraceRecorder trace;
+
+    @Inject
+    public ConstructorInjectedAgent(ExecutionTraceRecorder trace) {
+        this.trace = trace;
+    }
+
+    @Trigger
+    public void onEvent(@Observes ConstructorInjectedEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ConstructorInjectedEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ConstructorInjectedEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record ConstructorInjectedEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InnerAgentContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InnerAgentContainer.java
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+public class InnerAgentContainer {
+
+    @Agent
+    @ApplicationScoped
+    public static class InnerAgent {
+
+        @Inject ExecutionTraceRecorder trace;
+
+        @Trigger
+        public void onEvent(@Observes InnerAgentEvent event) {
+            trace.record(Phase.TRIGGER, "onEvent", event);
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InnerAgentEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InnerAgentEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record InnerAgentEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InterceptedAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InterceptedAgent.java
@@ -1,0 +1,49 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class InterceptedAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes InterceptedEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+
+    @Action
+    @AgentInterceptorBinding
+    public void process(InterceptedEvent event) {
+        trace.record(Phase.ACTION, "process", event);
+    }
+
+    // Interceptor bound to the @Outcome phase too — proves interception applies
+    // to any business-method phase the RI dispatches, not only @Action.
+    @Outcome
+    @AgentInterceptorBinding
+    public void finish(InterceptedEvent event) {
+        trace.record(Phase.OUTCOME, "finish", event);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InterceptedEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/InterceptedEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record InterceptedEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/LifecycleCallbackRecorder.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/LifecycleCallbackRecorder.java
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@ApplicationScoped
+public class LifecycleCallbackRecorder {
+
+    private final AtomicInteger postConstructCount = new AtomicInteger(0);
+    private final AtomicInteger preDestroyCount    = new AtomicInteger(0);
+    private final List<String>  instanceIds        = Collections.synchronizedList(new ArrayList<>());
+
+    public void recordPostConstruct(String instanceId) {
+        postConstructCount.incrementAndGet();
+        instanceIds.add(instanceId);
+    }
+
+    public void recordPreDestroy() { preDestroyCount.incrementAndGet(); }
+
+    public int          getPostConstructCount() { return postConstructCount.get(); }
+    public int          getPreDestroyCount()    { return preDestroyCount.get(); }
+    public List<String> getInstanceIds()        { return List.copyOf(instanceIds); }
+
+    public void reset() {
+        postConstructCount.set(0);
+        preDestroyCount.set(0);
+        instanceIds.clear();
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/LifecycleSpyAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/LifecycleSpyAgent.java
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.ai.agent.WorkflowScoped;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.UUID;
+
+@Agent(name = "lifecycleSpy")
+@WorkflowScoped
+public class LifecycleSpyAgent {
+
+    // Static so the failure-path test can configure it without injecting this
+    // @WorkflowScoped bean (no active context outside the RI). Default false keeps
+    // the success-path tests unchanged.
+    private static volatile boolean failInAction = false;
+    public static void setFailInAction(boolean value) { failInAction = value; }
+
+    private String instanceId;
+
+    @Inject ExecutionTraceRecorder    trace;
+    @Inject LifecycleCallbackRecorder lifecycleRecorder;
+
+    @PostConstruct
+    void init() {
+        instanceId = UUID.randomUUID().toString();
+        lifecycleRecorder.recordPostConstruct(instanceId);
+    }
+
+    @PreDestroy
+    void destroy() {
+        lifecycleRecorder.recordPreDestroy();
+    }
+
+    @Trigger
+    public void onEvent(@Observes LifecycleSpyEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event, instanceId);
+    }
+
+    @Action
+    public void process(LifecycleSpyEvent event) {
+        trace.record(Phase.ACTION, "process", event, instanceId);
+        if (failInAction) {
+            throw new IllegalStateException("Simulated @Action failure for @PreDestroy-on-failure test");
+        }
+    }
+
+    @Outcome
+    public void finish(LifecycleSpyEvent event) {
+        trace.record(Phase.OUTCOME, "finish", event, instanceId);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/LifecycleSpyEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/LifecycleSpyEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record LifecycleSpyEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ResolutionCdiBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ResolutionCdiBean.java
@@ -1,0 +1,20 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ResolutionCdiBean {
+    public String label() { return "cdi-service"; }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ResolutionOrderAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ResolutionOrderAgent.java
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Decision;
+import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class ResolutionOrderAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes ResolutionOrderEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+
+    // Priority 1 (event) + Priority 3 (LLM)
+    @Decision
+    public boolean decide(ResolutionOrderEvent event, LargeLanguageModel llm) {
+        trace.record(Phase.DECISION, "decide", event, llm);
+        return true;
+    }
+
+    // Priority 1 (event) + Priority 3 (LLM) + Priority 4 (CDI bean)
+    @Action
+    public void process(ResolutionOrderEvent event, LargeLanguageModel llm, ResolutionCdiBean service) {
+        trace.record(Phase.ACTION, "process", event, llm, service);
+    }
+
+    // Priority 1 (event) + Priority 4 (CDI bean)
+    @Outcome
+    public void finish(ResolutionOrderEvent event, ResolutionCdiBean service) {
+        trace.record(Phase.OUTCOME, "finish", event, service);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ResolutionOrderEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ResolutionOrderEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record ResolutionOrderEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ScopeDefaultAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ScopeDefaultAgent.java
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.UUID;
+
+// Intentionally NO scope annotation — the RI must default to @WorkflowScoped.
+// Under annotated discovery mode this class is NOT a CDI bean.
+@Agent
+public class ScopeDefaultAgent {
+
+    private String instanceId;
+
+    @Inject ExecutionTraceRecorder    trace;
+    @Inject LifecycleCallbackRecorder lifecycleRecorder;
+
+    @PostConstruct
+    void init() {
+        instanceId = UUID.randomUUID().toString();
+        lifecycleRecorder.recordPostConstruct(instanceId);
+    }
+
+    @Trigger
+    public void onEvent(@Observes ScopeDefaultEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event, instanceId);
+    }
+
+    @Action
+    public void process(ScopeDefaultEvent event) {
+        trace.record(Phase.ACTION, "process", event, instanceId);
+    }
+
+    @Outcome
+    public void finish(ScopeDefaultEvent event) {
+        trace.record(Phase.OUTCOME, "finish", event, instanceId);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ScopeDefaultEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/ScopeDefaultEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record ScopeDefaultEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/SingletonCdiAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/SingletonCdiAgent.java
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Agent
+@ApplicationScoped
+public class SingletonCdiAgent {
+
+    private static final AtomicInteger INSTANCE_COUNTER = new AtomicInteger(0);
+    private int instanceId;
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @PostConstruct
+    void init() {
+        instanceId = INSTANCE_COUNTER.incrementAndGet();
+    }
+
+    public static int getInstanceCount() { return INSTANCE_COUNTER.get(); }
+    public int getInstanceId()           { return instanceId; }
+
+    @Trigger
+    public void onEvent(@Observes SingletonCdiEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event, instanceId);
+    }
+
+    @Action
+    public void process(SingletonCdiEvent event) {
+        trace.record(Phase.ACTION, "process", event, instanceId);
+    }
+
+    @Outcome
+    public void finish(SingletonCdiEvent event) {
+        trace.record(Phase.OUTCOME, "finish", event, instanceId);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/SingletonCdiEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/cdi/SingletonCdiEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.cdi;
+
+public record SingletonCdiEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/AnchoredAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/AnchoredAgent.java
@@ -1,0 +1,52 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Decision;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class AnchoredAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Outcome
+    public void finish() {
+        trace.record(Phase.OUTCOME, "finish");
+    }
+
+    @Action
+    public void act(AnchoredEvent event) {
+        trace.record(Phase.ACTION, "act", event);
+    }
+
+    @Decision
+    public boolean decide(AnchoredEvent event) {
+        trace.record(Phase.DECISION, "decide", event);
+        return true;
+    }
+
+    @Trigger
+    public void onEvent(@Observes AnchoredEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/AnchoredEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/AnchoredEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+public record AnchoredEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/BranchingAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/BranchingAgent.java
@@ -1,0 +1,70 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Decision;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class BranchingAgent {
+
+    public enum TerminationPoint { FIRST_DECISION, SECOND_DECISION }
+
+    @Inject ExecutionTraceRecorder trace;
+    private volatile TerminationPoint terminateAt = TerminationPoint.FIRST_DECISION;
+
+    public void setTerminateAt(TerminationPoint terminateAt) {
+        this.terminateAt = terminateAt;
+    }
+
+    @Trigger
+    public void onEvent(@Observes BranchingEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+
+    @Decision
+    public boolean firstDecide(BranchingEvent event) {
+        trace.record(Phase.DECISION, "firstDecide", event);
+        return terminateAt != TerminationPoint.FIRST_DECISION;
+    }
+
+    @Action
+    public void firstAction(BranchingEvent event) {
+        trace.record(Phase.ACTION, "firstAction", event);
+    }
+
+    @Decision
+    public boolean secondDecide(BranchingEvent event) {
+        trace.record(Phase.DECISION, "secondDecide", event);
+        return terminateAt != TerminationPoint.SECOND_DECISION;
+    }
+
+    @Action
+    public void secondAction(BranchingEvent event) {
+        trace.record(Phase.ACTION, "secondAction", event);
+    }
+
+    @Outcome
+    public void finish() {
+        trace.record(Phase.OUTCOME, "finish");
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/BranchingEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/BranchingEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+public record BranchingEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/IntermixedAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/IntermixedAgent.java
@@ -1,0 +1,63 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Decision;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class IntermixedAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes IntermixedEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+
+    @Decision
+    public boolean firstDecide(IntermixedEvent event) {
+        trace.record(Phase.DECISION, "firstDecide", event);
+        return true;
+    }
+
+    @Action
+    public void firstAction(IntermixedEvent event) {
+        trace.record(Phase.ACTION, "firstAction", event);
+    }
+
+    @Decision
+    public boolean secondDecide(IntermixedEvent event) {
+        trace.record(Phase.DECISION, "secondDecide", event);
+        return true;
+    }
+
+    @Action
+    public void secondAction(IntermixedEvent event) {
+        trace.record(Phase.ACTION, "secondAction", event);
+    }
+
+    @Outcome
+    public void finish() {
+        trace.record(Phase.OUTCOME, "finish");
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/IntermixedEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/IntermixedEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+public record IntermixedEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/LinearAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/LinearAgent.java
@@ -1,0 +1,55 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class LinearAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes LinearEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+
+    @Action
+    public void firstAction(LinearEvent event) {
+        trace.record(Phase.ACTION, "firstAction", event);
+    }
+
+    @Action
+    public void secondAction(LinearEvent event) {
+        trace.record(Phase.ACTION, "secondAction", event);
+    }
+
+    @Action
+    public void thirdAction(LinearEvent event) {
+        trace.record(Phase.ACTION, "thirdAction", event);
+    }
+
+    @Outcome
+    public void finish() {
+        trace.record(Phase.OUTCOME, "finish");
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/LinearEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/LinearEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+public record LinearEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/MinimalistAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/MinimalistAgent.java
@@ -1,0 +1,33 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class MinimalistAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes MinimalistEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/MinimalistEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/MinimalistEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+public record MinimalistEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/OutcomeOnlyAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/OutcomeOnlyAgent.java
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.Decision;
+import jakarta.ai.agent.Outcome;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class OutcomeOnlyAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes OutcomeOnlyEvent event) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+    }
+
+    @Decision
+    public boolean decide(OutcomeOnlyEvent event) {
+        trace.record(Phase.DECISION, "decide", event);
+        return true;
+    }
+
+    @Outcome
+    public void finish() {
+        trace.record(Phase.OUTCOME, "finish");
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/OutcomeOnlyEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/orchestration/OutcomeOnlyEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.orchestration;
+
+public record OutcomeOnlyEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/cdi/AgentCdiMetadataTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/cdi/AgentCdiMetadataTests.java
@@ -1,0 +1,38 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.cdi;
+
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
+import jakarta.ai.agent.Agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Standalone
+public class AgentCdiMetadataTests {
+
+    @Agent(name = "customAgent", description = "A test agent for BHV-002")
+    private static class NamedAgentFixture {}
+
+    @Assertion(id = "AGENTICAI-CDI-BHV-002",
+               section = "Architecture, Convention over Configuration",
+               strategy = "@Agent.name() and @Agent.description() are retained and readable at runtime via "
+                        + "reflection; a class annotated @Agent(name=\"customAgent\", description=...) returns "
+                        + "those values from getAnnotation(Agent.class)")
+    public void agentNameAndDescriptionAttributesAreAccessibleAtRuntime() {
+        Agent annotation = NamedAgentFixture.class.getAnnotation(Agent.class);
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.name()).isEqualTo("customAgent");
+        assertThat(annotation.description()).isEqualTo("A test agent for BHV-002");
+    }
+}


### PR DESCRIPTION
## Summary

Adds behavioral TCK coverage for `@Agent` as a CDI-managed bean, covering assertions `AGENTICAI-CDI-BHV-001` through `AGENTICAI-CDI-BHV-007`: agent discovery & naming, `@WorkflowScoped`/`@ApplicationScoped` lifecycle, `@PostConstruct`/`@PreDestroy` callbacks, CDI interceptors, and method-parameter resolution priority.

### New test classes
- `AgentCdiMetadataTests` (`@Standalone`) — `@Agent` name/description readable at runtime via reflection.
- `CdiIntegrationTests` (`@Deployed`, all `@ApplicationScoped` agents) — discovery of static-nested and constructor-injected agents, client-proxy injection, `@PostConstruct`-once, instance reuse across workflows, plus interceptor and parameter-resolution preconditions. RI-dependent assertions are `@Disabled`.
- `WorkflowScopeLifecycleTests` (`@Deployed`, isolated) — `@WorkflowScoped`/no-scope agents for instance isolation, default camelCase naming, custom naming, and `@PreDestroy` on success and failure. All `@Disabled` pending a Reference Implementation, but the archive boots under weld-embedded.

Plus 18 agent/event/helper fixtures under `core/behavior/agents/cdi/`. The interceptor is enabled solely via the deployment `beans.xml` `<interceptors>` (no `@Priority`) to avoid double-enablement.

### Build fix
The `weld-embedded` profile's `<excludedGroups/>` was being *merged* with the base failsafe config rather than overriding it, so the `deployed` group stayed excluded and **no `@Deployed` Arquillian test ever ran**. Switched to `combine.self="override"`; all previously-dormant deployed tests now execute and pass.

## Test plan
- [x] `mvn --projects tck --also-make test-compile` — clean compile
- [x] `mvn --projects tck --also-make verify -Pweld-embedded` — 160 run, 50 skipped, 0 failures
- [x] New: 9 passing (1 standalone + 8 deployed), 11 `@Disabled(NO_RI)`
- [x] No regressions; previously-excluded deployed suites (orchestration, error-handling, etc.) now run green