### PR TITLE
FISH-13597 Behavioral TCK tests for LargeLanguageModel interface contract

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -117,6 +117,19 @@
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
         </dependency>
+
+        <!-- Jakarta JSON-B — compile scope: stub in src/main/java references Jsonb/JsonbBuilder -->
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>3.0.4</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/LlmContractTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/LlmContractTests.java
@@ -1,0 +1,249 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior;
+
+import ee.jakarta.tck.ai.agent.core.behavior.agents.llm.LlmQuerierAgent;
+import ee.jakarta.tck.ai.agent.core.behavior.agents.llm.LlmQuerierEvent;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Deployed;
+import ee.jakarta.tck.ai.agent.framework.stub.LargeLanguageModelStub;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.LLMException;
+import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Deployed
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LlmContractTests {
+
+    private static final String NO_RI =
+            "Requires a Reference Implementation orchestration engine to drive @WorkflowScoped "
+          + "workflow contexts (and ideally concurrent executions).";
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "llmcontract.war")
+                .addClasses(LlmQuerierAgent.class, LlmQuerierEvent.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject LargeLanguageModel     llm;
+    @Inject LargeLanguageModelStub stub;
+    @Inject Event<LlmQuerierEvent> events;
+    @Inject ExecutionTraceRecorder trace;
+
+    public static record PersonFixture(String name, int age) {}
+
+    // -------------------------------------------------------------------------
+    // A. Portable contract tests — assert against LargeLanguageModel interface
+    // -------------------------------------------------------------------------
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Input Integrity",
+               strategy = "null prompt on single-arg overload must throw IllegalArgumentException immediately")
+    public void nullPromptThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> llm.query(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Input Integrity",
+               strategy = "null prompt on varargs overload must throw IllegalArgumentException immediately")
+    public void nullPromptWithParamsThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> llm.query(null, "x"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Input Integrity",
+               strategy = "null resultType on typed overload must throw IllegalArgumentException immediately")
+    public void nullResultTypeThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> llm.query("p", (Class<?>) null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Positional Parameters",
+               strategy = "more parameters than placeholders must throw IllegalArgumentException")
+    public void arityMoreParamsThanPlaceholdersThrows() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        assertThatThrownBy(() -> llm.query("one {} here", "a", "b"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Positional Parameters",
+               strategy = "fewer parameters than placeholders must throw IllegalArgumentException")
+    public void arityFewerParamsThanPlaceholdersThrows() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        assertThatThrownBy(() -> llm.query("two {} and {}", "only"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Positional Parameters",
+               strategy = "prompt with no placeholder receiving multiple params must throw IllegalArgumentException")
+    public void noPlaceholderRejectsMultipleParams() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        assertThatThrownBy(() -> llm.query("Analyze this", "a", "b"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-006",
+               section = "LLM Interface, Provider Abstraction",
+               strategy = "unwrap to an incompatible type must throw IllegalArgumentException")
+    public void unwrapToIncompatibleTypeThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> llm.unwrap(String.class))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // B. Reference-stub tests — scripted; validate impl + document the contract
+    // -------------------------------------------------------------------------
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-001",
+               section = "API Overview, LLM Interface",
+               strategy = "positional {} placeholders are substituted in declaration order via JSON-B")
+    public void positionalPlaceholdersSubstitutedInOrderViaJsonB() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        llm.query("Hello {} and {}", "Alice", "Bob");
+        assertThat(stub.lastCall().effectivePrompt()).isEqualTo("Hello \"Alice\" and \"Bob\"");
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-001",
+               section = "API Overview, LLM Interface",
+               strategy = "look-alike tokens ({name}, { }) are not treated as positional placeholders")
+    public void lookAlikeTokensAreNotPlaceholders() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        // Explicit empty varargs array forces the varargs overload (3) so the substitution
+        // engine actually runs; the single-arg overload bypasses placeholder scanning entirely.
+        assertThatCode(() -> llm.query("{name} and { } stay literal", new Object[0]))
+                .doesNotThrowAnyException();
+        assertThat(stub.lastCall().effectivePrompt()).isEqualTo("{name} and { } stay literal");
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Positional Parameters",
+               strategy = "prompt with no placeholder allows exactly one structured context parameter")
+    public void noPlaceholderAllowsSingleStructuredContextParam() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        PersonFixture context = new PersonFixture("A", 1);
+        assertThatCode(() -> llm.query("Analyze this", context))
+                .doesNotThrowAnyException();
+        // Prompt is unchanged (no placeholder to substitute) but the structured param is recorded.
+        assertThat(stub.lastCall().effectivePrompt()).isEqualTo("Analyze this");
+        assertThat(stub.lastCall().params()).hasSize(1);
+        assertThat(stub.lastCall().params()[0]).isSameAs(context);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-003",
+               section = "Architecture, JSON-B",
+               strategy = "complex object parameters are serialized into the prompt via Jakarta JSON Binding")
+    public void complexObjectSerializedViaJsonBinding() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        llm.query("Profile: {}", new PersonFixture("Alice", 30));
+        assertThat(stub.lastCall().effectivePrompt())
+                .contains("\"name\":\"Alice\"")
+                .contains("\"age\":30");
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-004",
+               section = "Architecture, JSON-B",
+               strategy = "typed response is deserialized from JSON string via Jakarta JSON Binding")
+    public void typedResponseDeserializedViaJsonBinding() {
+        stub.reset();
+        stub.enqueueResponse("{\"name\":\"Bob\",\"age\":25}");
+        PersonFixture p = llm.query("give person", PersonFixture.class);
+        assertThat(p.name()).isEqualTo("Bob");
+        assertThat(p.age()).isEqualTo(25);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-005",
+               section = "LLM Interface, Error Semantics",
+               strategy = "LLM service error propagates as LLMException")
+    public void serviceErrorPropagatesAsLlmException() {
+        stub.reset();
+        stub.failWith(new LLMException("service down"));
+        assertThatThrownBy(() -> llm.query("p"))
+                .isInstanceOf(LLMException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-005",
+               section = "LLM Interface, Error Semantics",
+               strategy = "type conversion failure propagates as IllegalArgumentException, not LLMException")
+    public void typeConversionFailurePropagatesAsIllegalArgumentException() {
+        stub.reset();
+        stub.enqueueResponse(Integer.valueOf(42));
+        assertThatThrownBy(() -> llm.query("p", PersonFixture.class))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-006",
+               section = "LLM Interface, Provider Abstraction",
+               strategy = "unwrap to the concrete stub type returns the same instance")
+    public void unwrapToCompatibleTypeReturnsImplementation() {
+        LargeLanguageModelStub unwrapped = llm.unwrap(LargeLanguageModelStub.class);
+        assertThat(unwrapped).isNotNull().isInstanceOf(LargeLanguageModelStub.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // C. Disabled — requires RI / spec-open
+    // -------------------------------------------------------------------------
+
+    @Disabled(NO_RI)
+    @Assertion(id = "AGENTICAI-LLM-BHV-007",
+               section = "Architecture, Concurrency",
+               strategy = "conversational state does not leak between sequential workflow executions "
+                        + "(sequential firing is a v1 proxy for concurrency)")
+    public void conversationalStateIsolatedBetweenWorkflows() {
+        stub.reset();
+        trace.reset();
+        stub.enqueueResponse("first");
+        stub.enqueueResponse("second");
+        events.fire(new LlmQuerierEvent("workflow-1"));
+        events.fire(new LlmQuerierEvent("workflow-2"));
+
+        // Structural: each workflow ran its @Trigger and produced exactly one LLM call,
+        // with the event payload serialized via JSON-B into the prompt.
+        assertThat(trace.phases()).containsExactly(Phase.TRIGGER, Phase.TRIGGER);
+        assertThat(stub.recordedCalls()).hasSize(2);
+        assertThat(stub.recordedCalls().get(0).effectivePrompt()).isEqualTo("turn for \"workflow-1\"");
+        assertThat(stub.recordedCalls().get(1).effectivePrompt()).isEqualTo("turn for \"workflow-2\"");
+
+        // Isolation guarantee (BHV-007 proper): each event must materialize its own
+        // @WorkflowScoped LLM context so the second call cannot observe the first
+        // workflow's conversational state. Verifiable only once the RI exposes
+        // per-workflow conversation history — this test currently asserts only the
+        // structural precondition.
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/llm/LlmQuerierAgent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/llm/LlmQuerierAgent.java
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.llm;
+
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder;
+import ee.jakarta.tck.ai.agent.framework.trace.ExecutionTraceRecorder.Phase;
+import jakarta.ai.agent.Action;
+import jakarta.ai.agent.Agent;
+import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.ai.agent.Trigger;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+@Agent
+@ApplicationScoped
+public class LlmQuerierAgent {
+
+    @Inject ExecutionTraceRecorder trace;
+
+    @Trigger
+    public void onEvent(@Observes LlmQuerierEvent event, LargeLanguageModel llm) {
+        trace.record(Phase.TRIGGER, "onEvent", event);
+        llm.query("turn for {}", event.payload());
+    }
+
+    @Action
+    public void execute(LlmQuerierEvent event) {
+        trace.record(Phase.ACTION, "execute", event);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/llm/LlmQuerierEvent.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/agents/llm/LlmQuerierEvent.java
@@ -1,0 +1,15 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.behavior.agents.llm;
+
+public record LlmQuerierEvent(String payload) {}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
@@ -13,79 +13,70 @@
 package ee.jakarta.tck.ai.agent.framework.stub;
 
 import jakarta.ai.agent.LargeLanguageModel;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 
 import java.time.Instant;
-import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * CDI-enabled stub for {@link LargeLanguageModel} used in TCK behavioral tests.
- * Provides a way to script responses and verify received prompts.
+ * Spec-faithful CDI stub for {@link LargeLanguageModel} used in TCK behavioral tests.
  *
- * <p>Responses and failures are queued and consumed in FIFO order.</p>
+ * <p>Enforces the spec contract: null-prompt/resultType → IAE, strict arity on varargs
+ * overloads, JSON-B serialization of parameters and deserialization of typed responses.
+ * Responses and failures are queued and consumed in FIFO order.</p>
  */
 @ApplicationScoped
 public class LargeLanguageModelStub implements LargeLanguageModel {
 
-    private final Queue<Object> scriptedResponses = new ArrayDeque<>();
-    private final Queue<RuntimeException> scriptedFailures = new ArrayDeque<>();
+    private final Jsonb jsonb = JsonbBuilder.create();
+    private final Queue<Object> scriptedResponses = new ConcurrentLinkedQueue<>();
+    private final Queue<RuntimeException> scriptedFailures = new ConcurrentLinkedQueue<>();
     private final List<RecordedCall> calls = new CopyOnWriteArrayList<>();
 
     /**
-     * Records a call to the model.
-     *
-     * @param prompt the prompt sent to the model
-     * @param resultType the expected result type, or null for default String queries
-     * @param params the parameters sent to the model
-     * @param overload the overload index (1-4)
-     * @param at the timestamp of the call
+     * Releases the underlying {@link Jsonb} instance when the CDI context shuts down.
+     * Yasson does not hold OS-level resources today, but the spec contract is to close it.
      */
-    public record RecordedCall(String prompt, Class<?> resultType, Object[] params, int overload, Instant at) {}
+    @PreDestroy
+    void close() {
+        try {
+            jsonb.close();
+        } catch (Exception ignored) {
+            // best-effort — the bean is going away anyway
+        }
+    }
 
     /**
-     * Enqueues a response to be returned by the next call to any query method.
-     *
-     * @param response the response object
+     * Records a call to the model. {@code prompt} is the raw template; {@code effectivePrompt}
+     * is the post-substitution text (equals {@code prompt} for single-arg overloads).
      */
+    public record RecordedCall(String prompt, String effectivePrompt, Class<?> resultType,
+                               Object[] params, int overload, Instant at) {}
+
     public void enqueueResponse(Object response) {
         scriptedResponses.add(response);
     }
 
-    /**
-     * Enqueues a failure to be thrown on the next call to any query method.
-     *
-     * @param e the exception to throw
-     */
     public void failWith(RuntimeException e) {
-        this.scriptedFailures.add(e);
+        scriptedFailures.add(e);
     }
 
-    /**
-     * Resets the stub's state (scripted responses, failures, and recorded calls).
-     */
     public void reset() {
         scriptedResponses.clear();
         scriptedFailures.clear();
         calls.clear();
     }
 
-    /**
-     * Returns a list of all recorded calls.
-     *
-     * @return the list of recorded calls
-     */
     public List<RecordedCall> recordedCalls() {
         return List.copyOf(calls);
     }
 
-    /**
-     * Returns the last recorded call, or null if no calls were made.
-     *
-     * @return the last recorded call
-     */
     public RecordedCall lastCall() {
         return calls.isEmpty() ? null : calls.get(calls.size() - 1);
     }
@@ -97,6 +88,7 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
 
     @Override
     public <T> T query(String prompt, Class<T> resultType) {
+        if (resultType == null) throw new IllegalArgumentException("resultType is null");
         return dispatch(prompt, resultType, 2);
     }
 
@@ -107,20 +99,18 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
 
     @Override
     public <T> T query(String prompt, Class<T> resultType, Object... parameters) {
+        if (resultType == null) throw new IllegalArgumentException("resultType is null");
         return dispatch(prompt, resultType, 4, parameters);
     }
 
-    @SuppressWarnings("unchecked")
     private <T> T dispatch(String prompt, Class<T> resultType, int overload, Object... params) {
-        if (prompt == null) {
-            throw new IllegalArgumentException("prompt is null");
-        }
-        calls.add(new RecordedCall(prompt, resultType, params, overload, Instant.now()));
+        if (prompt == null) throw new IllegalArgumentException("prompt is null");
 
-        RuntimeException scriptedFailure = scriptedFailures.poll();
-        if (scriptedFailure != null) {
-            throw scriptedFailure;
-        }
+        String effectivePrompt = (overload >= 3) ? applyPlaceholders(prompt, params) : prompt;
+        calls.add(new RecordedCall(prompt, effectivePrompt, resultType, params, overload, Instant.now()));
+
+        RuntimeException failure = scriptedFailures.poll();
+        if (failure != null) throw failure;
 
         Object next = scriptedResponses.poll();
         if (next == null) {
@@ -129,19 +119,54 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
                   + "Call enqueueResponse(...) before invoking the LLM in this test.");
         }
 
-        if (resultType != null && !resultType.isInstance(next)) {
-            // For String result type, fall back to toString() conversion of the queued value.
-            if (resultType == String.class) {
-                return (T) next.toString();
-            }
-            // Spec contract: type conversion failures are reported as IllegalArgumentException
-            // (see LargeLanguageModel.query Javadoc).
-            throw new IllegalArgumentException(
-                    "Cannot convert queued response of type " + next.getClass().getName()
-                  + " to requested result type " + resultType.getName());
-        }
+        return convert(next, resultType);
+    }
 
-        return (T) (resultType == null ? next.toString() : next);
+    private String applyPlaceholders(String prompt, Object[] params) {
+        int n = countExactBraces(prompt);
+        if (n >= 1 && params.length != n) {
+            throw new IllegalArgumentException(
+                "placeholder/parameter arity mismatch: " + n + " vs " + params.length);
+        }
+        if (n == 0 && params.length > 1) {
+            throw new IllegalArgumentException(
+                "prompt has no placeholder but received " + params.length + " parameters");
+        }
+        if (n == 0) {
+            // single structured context param — keep raw prompt as effective text
+            return prompt;
+        }
+        String result = prompt;
+        for (Object p : params) {
+            result = result.replaceFirst(java.util.regex.Pattern.quote("{}"),
+                     java.util.regex.Matcher.quoteReplacement(jsonb.toJson(p)));
+        }
+        return result;
+    }
+
+    private int countExactBraces(String prompt) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = prompt.indexOf("{}", idx)) != -1) {
+            count++;
+            idx += 2;
+        }
+        return count;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T convert(Object next, Class<T> resultType) {
+        if (resultType == null)          return (T) next.toString();
+        if (resultType.isInstance(next)) return (T) next;
+        if (resultType == String.class)  return (T) next.toString();
+        if (next instanceof String json) {
+            try {
+                return jsonb.fromJson(json, resultType);
+            } catch (jakarta.json.bind.JsonbException e) {
+                throw new IllegalArgumentException("type conversion failed", e);
+            }
+        }
+        throw new IllegalArgumentException("Cannot convert " + next.getClass() + " to " + resultType);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds behavioral TCK coverage for the `LargeLanguageModel` facade (assertion IDs `AGENTICAI-LLM-BHV-001` .. `AGENTICAI-LLM-BHV-007`) and upgrades the `LargeLanguageModelStub` to a spec-faithful reference implementation so the contract is genuinely exercised.

> Stacked on top of #37 (FISH-13595) and #38 (FISH-13596). The diff above main reflects that until those merge.

## Stub enhancements (`LargeLanguageModelStub`)

- Reject `null resultType` with `IllegalArgumentException` on both typed `query` overloads, before dispatch.
- Validate placeholder/parameter arity on the varargs overloads; the single-arg overloads pass the prompt through literally (no `{}` semantics).
- Substitute positional `{}` placeholders via Jakarta JSON Binding in declaration order; only non-overlapping `{}` count, so `{name}` / `{ }` stay literal.
- Record the effective post-substitution prompt as a new field on `RecordedCall`; the raw `prompt()` is preserved for existing callers.
- Deserialize typed responses via JSON-B when a JSON string is queued; map `JsonbException` to `IllegalArgumentException` (client-side error).
- Use `ConcurrentLinkedQueue` for scripted responses and failures, consistent with the existing `CopyOnWriteArrayList` for recorded calls — safe under concurrent workflow dispatch (BHV-007 stretch goal).
- Close the `Jsonb` instance via `@PreDestroy` on CDI context shutdown.

## New test fixtures

- `LlmQuerierEvent` — workflow trigger payload record.
- `LlmQuerierAgent` — `@ApplicationScoped` `@Agent` whose `@Trigger` injects `LargeLanguageModel` and calls `query()` with the event payload; `@Action` is recorded for the RI-driven isolation test.

## New test class — `LlmContractTests` (`@Deployed`, `PER_CLASS`)

**A. Portable contract tests against the `LargeLanguageModel` interface (7)**
- `null` prompt and `null` `resultType` throw IAE on all relevant overloads.
- Arity mismatches (more/fewer params, no-placeholder with multiple params) throw IAE.
- `unwrap` to an incompatible type throws IAE.

**B. Reference-stub tests using scripted responses (8)**
- Positional substitution in declaration order via JSON-B (strings serialize quoted).
- Look-alike tokens (`{name}`, `{ }`) stay literal under the varargs overload (explicit empty `Object[]` forces the substitution engine to run).
- Structured context param with no placeholder is preserved untouched.
- Complex object parameter serialized via JSON-B.
- Typed response deserialized via JSON-B.
- LLM service error propagates as `LLMException`; type-conversion failure propagates as `IllegalArgumentException`.
- `unwrap` to the concrete stub type returns the implementation.

**C. Disabled (1)**
- `conversationalStateIsolatedBetweenWorkflows` (BHV-007): structural assertions on trace and recorded calls run as-is; the per-workflow isolation guarantee remains RI-dependent. Sequential firing is documented as a v1 proxy for concurrency.

## Spec gap (not covered, on purpose)

Brace-escaping (`{{}}`) is mentioned as a look-alike in the issue, but the spec Javadoc defines no escape rule and a naive `{}` scan counts `{{}}` as one placeholder. The TCK does not bake a guess in — to be revisited once the rule is clarified.

## POM changes (already committed)

Jakarta JSON Binding API (compile) + Yasson (runtime) added in `545637f`. Stub lives in `src/main/java`, so neither can be test-scoped.

## Decisions

- **JSON-B quoting**: `query("Hello {}", "Alice")` produces `Hello "Alice"` (JSON-B quotes strings). Tests assert the quoted form — spec-correct.
- **`PersonFixture`** declared `public static record` (not `private`) so Yasson, running as a named module, can access its accessors via reflection.
- **Portable vs reference-stub**: group A asserts against the interface (vendor-portable). Group B uses stub scripting (`enqueueResponse`, `failWith`, `effectivePrompt`) and validates the reference impl while documenting the contract.

## Verification

`mvn --projects tck --also-make verify -Pweld-embedded` — **BUILD SUCCESS**: 176 tests, 0 failures, 0 errors, 51 skipped (+16 over the previous baseline: 15 active + 1 disabled).

Closes FISH-13597.