### PR TITLE
Add TCK coverage for query(String, Class, Object...) exception contract and LLMException(Throwable) signature check

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/LlmContractTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/behavior/LlmContractTests.java
@@ -139,6 +139,41 @@ public class LlmContractTests {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Positional Parameters",
+               strategy = "parameter that cannot be converted on the typed varargs overload must throw IllegalArgumentException")
+    public void parameterSerializationFailureOnTypedOverloadThrowsIllegalArgumentException() {
+        stub.reset();
+        assertThatThrownBy(() -> llm.query("process {}", PersonFixture.class, new NonSerializableParam()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Input Integrity",
+               strategy = "null prompt on the typed varargs overload must throw IllegalArgumentException immediately")
+    public void nullPromptOnTypedVarargsOverloadThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> llm.query(null, PersonFixture.class, "x"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Input Integrity",
+               strategy = "null resultType on the typed varargs overload must throw IllegalArgumentException immediately")
+    public void nullResultTypeOnTypedVarargsOverloadThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> llm.query("p", (Class<?>) null, "x"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-002",
+               section = "LLM Interface, Positional Parameters",
+               strategy = "more parameters than placeholders on the typed varargs overload must throw IllegalArgumentException")
+    public void arityMismatchOnTypedVarargsOverloadThrows() {
+        stub.reset();
+        stub.enqueueResponse("ok");
+        assertThatThrownBy(() -> llm.query("one {} here", PersonFixture.class, "a", "b"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
     @Assertion(id = "AGENTICAI-LLM-BHV-006",
                section = "LLM Interface, Provider Abstraction",
                strategy = "unwrap to an incompatible type must throw IllegalArgumentException")
@@ -229,6 +264,16 @@ public class LlmContractTests {
         stub.reset();
         stub.enqueueResponse(Integer.valueOf(42));
         assertThatThrownBy(() -> llm.query("p", PersonFixture.class))
+                .isInstanceOf(LLMException.class);
+    }
+
+    @Assertion(id = "AGENTICAI-LLM-BHV-005",
+               section = "LLM Interface, Error Semantics",
+               strategy = "response type conversion failure on the typed varargs overload propagates as LLMException")
+    public void typeConversionFailureOnTypedVarargsOverloadPropagatesAsLlmException() {
+        stub.reset();
+        stub.enqueueResponse(Integer.valueOf(42));
+        assertThatThrownBy(() -> llm.query("p", PersonFixture.class, "irrelevant"))
                 .isInstanceOf(LLMException.class);
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/signature/SignatureTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/signature/SignatureTests.java
@@ -214,6 +214,12 @@ public class SignatureTests {
             assertTrue(hasStringThrowableConstructor,
                     "LLMException must have a constructor with String and Throwable parameters");
 
+            boolean hasThrowableConstructor = Arrays.stream(llmExceptionClass.getDeclaredConstructors())
+                    .anyMatch(c -> c.getParameterCount() == 1 &&
+                            c.getParameterTypes()[0].equals(Throwable.class));
+            assertTrue(hasThrowableConstructor,
+                    "LLMException must have a constructor with Throwable parameter");
+
         } catch (ClassNotFoundException e) {
             fail("LLMException class not found: " + e.getMessage());
         }


### PR DESCRIPTION
### Background
Reza's commit `303141d` clarified the `LLM` exception contract:
* **Input serialization failure** → `IllegalArgumentException`
* **Response deserialization failure** → `LLMException`

The TCK was updated for the two- and three-argument overloads, but the four-argument overload `query(String, Class<T>, Object...)` was missed entirely. This PR closes that gap and completes the `LLMException` signature check.

---

### Gap 1: `query(String, Class<T>, Object...)` not covered

`LlmContractTests.parameterSerializationFailureThrowsIllegalArgumentException` calls `llm.query("process {}", new NonSerializableParam())`. Java resolves this to `query(String, Object...)` (the string-return varargs overload), **not** `query(String, Class, Object...)`.

The four-argument overload carries the same Javadoc contract but was untested for both exception paths **and** its input-validation guards. This PR adds five tests against it:

**Exception contract**
- `parameterSerializationFailureOnTypedOverloadThrowsIllegalArgumentException` (`AGENTICAI-LLM-BHV-002`) — input serialization failure → `IllegalArgumentException`
- `typeConversionFailureOnTypedVarargsOverloadPropagatesAsLlmException` (`AGENTICAI-LLM-BHV-005`) — response deserialization failure → `LLMException`

**Input-validation guards** (`AGENTICAI-LLM-BHV-002`)
- `nullPromptOnTypedVarargsOverloadThrowsIllegalArgumentException` — null prompt → `IllegalArgumentException`
- `nullResultTypeOnTypedVarargsOverloadThrowsIllegalArgumentException` — null `resultType` → `IllegalArgumentException`
- `arityMismatchOnTypedVarargsOverloadThrows` — more parameters than `{}` placeholders → `IllegalArgumentException`

---

### Gap 2: `SignatureTests` missing `LLMException(Throwable)` constructor check

`SignatureTests.testLLMExceptionSignature()` (`AGENTICAI-SIG-008`) verified `LLMException(String)` and `LLMException(String, Throwable)` but **not** `LLMException(Throwable)`. The API has this constructor, and `LLMExceptionTests.testLLMExceptionThrowableConstructor` exercises it functionally, but the signature test — the authoritative API surface check — was incomplete. This PR adds the missing check.

---

### Note on assertion IDs
`AGENTICAI-LLMEXCEPTION-003` (the former no-arg constructor test removed in `303141d`) is intentionally left retired rather than renumbered — assertion IDs are stable identifiers, so the gap in the sequence is expected.

---

### Verification
`mvn --projects tck --also-make verify -Pweld-embedded` — **BUILD SUCCESS**
- `LlmContractTests`: 22 run, 0 failures (1 pre-existing `@Disabled` concurrency test skipped) — up from 17
- `SignatureTests`: 12 run, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)