### PR TITLE
Pin maven-compiler-plugin so maven.compiler.release is honoured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,4 +65,24 @@
         <nexus.staging.repository>agentic-ai-staging</nexus.staging.repository>
         <project.build.outputTimestamp>2026-04-12T00:00:00Z</project.build.outputTimestamp>
     </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!--
+                    Pin a maven-compiler-plugin version that honours
+                    maven.compiler.release. Without this, the build falls back
+                    to the Maven super-POM default (3.1), which predates the
+                    'release' option and compiles with source/target 1.5,
+                    failing on modern JDKs with "Source option 5 is no longer
+                    supported".
+                -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
## Problem

Building the project on a modern JDK (e.g. 21) fails while compiling `jakarta.agentic-ai-api`:

```
[ERROR] Source option 5 is no longer supported. Use 8 or later.
[ERROR] Target option 5 is no longer supported. Use 8 or later.
```

The parent POM already sets `maven.compiler.release=17`, but no `maven-compiler-plugin` version is declared anywhere in the build. As a result Maven falls back to the super-POM default (`maven-compiler-plugin` **3.1**), which predates the `release` option and therefore ignores `maven.compiler.release`, compiling with `source/target 1.5` instead.

This currently breaks downstream consumers that build the API/spec/TCK from source (e.g. Jakarta EE TCK runners) on JDK 8+.

## Fix

Pin a recent `maven-compiler-plugin` (`3.13.0`) via `<pluginManagement>` in the parent POM. This makes the existing `maven.compiler.release=17` property take effect across all modules, with no per-module changes required.

## Testing

`mvn -pl api -am clean install` now succeeds on JDK 21 (previously failed with the "option 5" error above).