### PR TITLE
Drop inaccurate comment about default maven-compiler-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.15.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -69,14 +69,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <!--
-                    Pin a maven-compiler-plugin version that honours
-                    maven.compiler.release. Without this, the build falls back
-                    to the Maven super-POM default (3.1), which predates the
-                    'release' option and compiles with source/target 1.5,
-                    failing on modern JDKs with "Source option 5 is no longer
-                    supported".
-                -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Follow-up to #47.

As noted in review by @pzygielo, the comment added alongside the pinned `maven-compiler-plugin` was inaccurate: the default compiler plugin version is determined by the Maven version in use (e.g. Maven 3.9.x binds a 3.15.x plugin), not a fixed 3.1. The comment was also longer than the self-explanatory plugin pin it described.

This removes the comment. The `maven-compiler-plugin` pin (which makes the existing `maven.compiler.release=17` take effect regardless of the Maven version) is unchanged.