### PR TITLE
[TCK] Add Result record value-semantics conformance tests

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/ResultTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/ResultTests.java
@@ -76,10 +76,10 @@ public class ResultTests {
                section = "API Types / Result",
                strategy = "Verify records with equal components are equal and share a hash code")
     public void testValueEquality() {
-        String details = "context";
-        Result a = new Result(true, details);
-        Result b = new Result(true, details);
-
+        String detailsA = new StringBuilder("context").toString();
+        String detailsB = new StringBuilder("context").toString();
+        Result a = new Result(true, detailsA);
+        Result b = new Result(true, detailsB);
         assertEquals(a, b,
                 "Results with equal components must be equal");
         assertEquals(a.hashCode(), b.hashCode(),

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/ResultTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/ResultTests.java
@@ -17,9 +17,12 @@ import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
 import jakarta.ai.agent.Result;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -36,11 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ResultTests {
 
     @Assertion(id = "AGENTICAI-RESULT-001",
-               section = "API Types / Result",
-               strategy = "Verify Result exists in jakarta.ai.agent and is a record")
+               strategy = "Verify Result is in jakarta.ai.agent and is a record")
     public void testResultIsRecord() {
-        assertNotNull(Result.class,
-                "Result must exist in jakarta.ai.agent package");
         assertEquals("jakarta.ai.agent", Result.class.getPackageName(),
                 "Result must be in jakarta.ai.agent package");
         assertTrue(Result.class.isRecord(),
@@ -48,7 +48,6 @@ public class ResultTests {
     }
 
     @Assertion(id = "AGENTICAI-RESULT-002",
-               section = "API Types / Result",
                strategy = "Verify success() and details() accessors return the constructor arguments")
     public void testAccessorsReturnConstructorArguments() {
         Object details = new Object();
@@ -56,28 +55,29 @@ public class ResultTests {
 
         assertTrue(result.success(),
                 "success() must return the value passed to the canonical constructor");
-        assertEquals(details, result.details(),
-                "details() must return the value passed to the canonical constructor");
+        assertSame(details, result.details(),
+                "details() must return the same instance passed to the canonical constructor");
     }
 
     @Assertion(id = "AGENTICAI-RESULT-003",
-               section = "API Types / Result",
                strategy = "Verify details may be null and a false success flag is preserved")
     public void testDetailsMayBeNull() {
         Result result = new Result(false, null);
 
-        assertTrue(!result.success(),
+        assertFalse(result.success(),
                 "success() must return false when constructed with false");
         assertNull(result.details(),
                 "details() must be allowed to be null");
     }
 
     @Assertion(id = "AGENTICAI-RESULT-004",
-               section = "API Types / Result",
                strategy = "Verify records with equal components are equal and share a hash code")
     public void testValueEquality() {
-        String detailsA = new StringBuilder("context").toString();
-        String detailsB = new StringBuilder("context").toString();
+        String detailsA = new String("context");
+        String detailsB = new String("context");
+        assertNotSame(detailsA, detailsB,
+                "precondition: details instances must be distinct so equality cannot pass by identity");
+
         Result a = new Result(true, detailsA);
         Result b = new Result(true, detailsB);
         assertEquals(a, b,
@@ -94,7 +94,6 @@ public class ResultTests {
     }
 
     @Assertion(id = "AGENTICAI-RESULT-005",
-               section = "API Types / Result",
                strategy = "Verify Results are unequal when the success flag or details differ")
     public void testInequalityWhenComponentsDiffer() {
         Result base = new Result(true, "context");
@@ -108,7 +107,6 @@ public class ResultTests {
     }
 
     @Assertion(id = "AGENTICAI-RESULT-006",
-               section = "API Types / Result",
                strategy = "Verify toString exposes the component values")
     public void testToStringExposesComponents() {
         Result result = new Result(true, "flagged");

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/ResultTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/core/agent/ResultTests.java
@@ -1,0 +1,123 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.core.agent;
+
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Assertion;
+import ee.jakarta.tck.ai.agent.framework.junit.anno.Standalone;
+import jakarta.ai.agent.Result;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * TCK tests for the {@link Result} record.
+ *
+ * <p>These tests verify the runtime value semantics of the {@code Result}
+ * record used as a {@link jakarta.ai.agent.Decision @Decision} return type.
+ * {@link ee.jakarta.tck.ai.agent.framework.signature.SignatureTests} already
+ * verifies the record's structure by reflection; these tests verify its
+ * behavior: accessors, nullability of {@code details}, value-based equality,
+ * and {@code toString}.
+ */
+@Standalone
+public class ResultTests {
+
+    @Assertion(id = "AGENTICAI-RESULT-001",
+               section = "API Types / Result",
+               strategy = "Verify Result exists in jakarta.ai.agent and is a record")
+    public void testResultIsRecord() {
+        assertNotNull(Result.class,
+                "Result must exist in jakarta.ai.agent package");
+        assertEquals("jakarta.ai.agent", Result.class.getPackageName(),
+                "Result must be in jakarta.ai.agent package");
+        assertTrue(Result.class.isRecord(),
+                "Result must be a record type");
+    }
+
+    @Assertion(id = "AGENTICAI-RESULT-002",
+               section = "API Types / Result",
+               strategy = "Verify success() and details() accessors return the constructor arguments")
+    public void testAccessorsReturnConstructorArguments() {
+        Object details = new Object();
+        Result result = new Result(true, details);
+
+        assertTrue(result.success(),
+                "success() must return the value passed to the canonical constructor");
+        assertEquals(details, result.details(),
+                "details() must return the value passed to the canonical constructor");
+    }
+
+    @Assertion(id = "AGENTICAI-RESULT-003",
+               section = "API Types / Result",
+               strategy = "Verify details may be null and a false success flag is preserved")
+    public void testDetailsMayBeNull() {
+        Result result = new Result(false, null);
+
+        assertTrue(!result.success(),
+                "success() must return false when constructed with false");
+        assertNull(result.details(),
+                "details() must be allowed to be null");
+    }
+
+    @Assertion(id = "AGENTICAI-RESULT-004",
+               section = "API Types / Result",
+               strategy = "Verify records with equal components are equal and share a hash code")
+    public void testValueEquality() {
+        String details = "context";
+        Result a = new Result(true, details);
+        Result b = new Result(true, details);
+
+        assertEquals(a, b,
+                "Results with equal components must be equal");
+        assertEquals(a.hashCode(), b.hashCode(),
+                "Equal Results must have equal hash codes");
+
+        Result nullA = new Result(false, null);
+        Result nullB = new Result(false, null);
+        assertEquals(nullA, nullB,
+                "Results with equal components (null details) must be equal");
+        assertEquals(nullA.hashCode(), nullB.hashCode(),
+                "Equal Results (null details) must have equal hash codes");
+    }
+
+    @Assertion(id = "AGENTICAI-RESULT-005",
+               section = "API Types / Result",
+               strategy = "Verify Results are unequal when the success flag or details differ")
+    public void testInequalityWhenComponentsDiffer() {
+        Result base = new Result(true, "context");
+
+        assertNotEquals(base, new Result(false, "context"),
+                "Results must be unequal when the success flag differs");
+        assertNotEquals(base, new Result(true, "other"),
+                "Results must be unequal when details differ");
+        assertNotEquals(base, new Result(true, null),
+                "Result with details must not equal Result with null details");
+    }
+
+    @Assertion(id = "AGENTICAI-RESULT-006",
+               section = "API Types / Result",
+               strategy = "Verify toString exposes the component values")
+    public void testToStringExposesComponents() {
+        Result result = new Result(true, "flagged");
+        String text = result.toString();
+
+        assertNotNull(text, "toString() must not be null");
+        assertTrue(text.contains("true"),
+                "toString() must expose the success component value");
+        assertTrue(text.contains("flagged"),
+                "toString() must expose the details component value");
+    }
+}


### PR DESCRIPTION
### What

Adds a standalone TCK test class ResultTests verifying the runtime value
semantics of the public jakarta.ai.agent.Result record: accessors, null
details, value-based equals/hashCode, inequality, and toString.

New assertion family: AGENTICAI-RESULT-001..006.

### Why

Result is the structured @Decision return type. Current coverage only checks
its structure by reflection (AGENTICAI-SIG-007) and its usability as a return
type (AGENTICAI-DECISION-007). The record's behavior  the part callers depend
on - was untested. Fixes #49.

### Scope

- Test-only. No change to api/ or any production type.
- @Standalone; runs in the default Failsafe run (no container).
- No signature-baseline change (sigtest strictcheck passes).

### Validation

mvn -B clean install - BUILD SUCCESS.
ResultTests - Tests run: 6, Failures: 0, Errors: 0, Skipped: 0.
Full TCK - Tests run: 82, Failures: 0, Errors: 0, Skipped: 0.

### Notes

Follows the existing TCK conventions (@Standalone, @Assertion ids, EPL-2.0
header, no author tag).