### PR TITLE
[TCK] Fail fast when declared mode conflicts with presence flag

### DIFF
--- a/TESTING-GUIDELINE.md
+++ b/TESTING-GUIDELINE.md
@@ -38,5 +38,41 @@ on the Surefire / Failsafe `argLine` (or globally on the test JVM). Leaving
 the property unset — the default — signals a plain-CDI run and skips the
 `@RequiresImplementation` assertions.
 
+## Declaring Expected Run Mode
+An optional second property declares the expected run mode so a misconfigured
+invocation fails fast instead of silently skipping the behavioral suite:
+
+```
+-Djakarta.ai.agent.tck.mode=implementation
+```
+
+or
+
+```
+-Djakarta.ai.agent.tck.mode=baseline
+```
+
+Rules:
+
+- `mode=implementation` requires `-Djakarta.ai.agent.tck.implementation.present=true`.
+  If the presence flag is missing or false, the run fails with a clear error.
+- `mode=baseline` requires the presence flag to be unset / false. If the
+  presence flag is true, the run fails.
+- When `jakarta.ai.agent.tck.mode` is unset, behavior is unchanged (default
+  baseline: `@RequiresImplementation` assertions are skipped).
+- Values are case-insensitive; unknown values fail fast.
+
+### Implementation-mode invocation
+Vendors running against a compatible implementation should set both properties:
+
+```
+mvn -pl tck verify -Pweld-embedded \
+  -Djakarta.ai.agent.tck.implementation.present=true \
+  -Djakarta.ai.agent.tck.mode=implementation
+```
+
+A plain-CDI baseline run needs neither property (or may set
+`-Djakarta.ai.agent.tck.mode=baseline` explicitly).
+
 ## Reporting Issues
 - Please report any test failures or compatibility issues via GitHub Issues.

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/ImplementationPresentCondition.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/ImplementationPresentCondition.java
@@ -34,6 +34,12 @@ import org.junit.platform.commons.support.AnnotationSupport;
  * implementation" — appropriate for a plain-CDI (Weld/OpenWebBeans) run of
  * the standalone assertions.</p>
  *
+ * <p>An optional expected-mode property {@value #TCK_MODE_PROPERTY} may be set
+ * to {@code implementation} or {@code baseline}. When set, the declared mode is
+ * checked against the presence flag inside the container so a misconfigured run
+ * fails fast instead of silently skipping the behavioral suite. When unset,
+ * today's default baseline behavior is preserved.</p>
+ *
  * <p>A system-property opt-in is used rather than a CDI-container probe so
  * this detector remains portable across CDI 4.0 (Jakarta EE 10) containers,
  * where the {@code BeanManager} does not expose a way to enumerate registered
@@ -57,6 +63,14 @@ public class ImplementationPresentCondition implements ExecutionCondition {
     public static final String IMPLEMENTATION_PRESENT_PROPERTY =
             "jakarta.ai.agent.tck.implementation.present";
 
+    /**
+     * Optional system property declaring the expected TCK run mode.
+     * Accepted values are {@code implementation} and {@code baseline}
+     * (case-insensitive). When unset, the default baseline behavior is preserved.
+     */
+    public static final String TCK_MODE_PROPERTY =
+            "jakarta.ai.agent.tck.mode";
+
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
         boolean requiresImplementation = AnnotationSupport.isAnnotated(context.getElement(), RequiresImplementation.class);
@@ -71,6 +85,8 @@ public class ImplementationPresentCondition implements ExecutionCondition {
                     "Implementation presence undetermined outside the container; deferring to the in-container evaluation");
         }
 
+        checkMode(System.getProperty(TCK_MODE_PROPERTY), implementationPresent);
+
         if (requiresImplementation) {
             return implementationPresent
                 ? ConditionEvaluationResult.enabled("Agentic AI compatible implementation is present")
@@ -82,6 +98,54 @@ public class ImplementationPresentCondition implements ExecutionCondition {
                 ? ConditionEvaluationResult.disabled("No-implementation baseline precondition; superseded by the "
                 + "@RequiresImplementation behavior assertion when a compatible implementation is present")
                 : ConditionEvaluationResult.enabled("No Agentic AI implementation present (plain-CDI baseline)");
+    }
+
+    /**
+     * Validates that an optional declared TCK mode is consistent with the
+     * detected implementation presence.
+     *
+     * <p>Package-private and free of system-property / CDI access so unit tests
+     * can exercise the guard directly.</p>
+     *
+     * @param mode                   value of {@value #TCK_MODE_PROPERTY}, or {@code null}/{@code blank} when unset
+     * @param implementationPresent  whether a compatible implementation is declared present
+     * @throws IllegalStateException when the declared mode conflicts with presence, or the value is unknown
+     */
+    static void checkMode(String mode, boolean implementationPresent) {
+        if (mode == null || mode.isBlank()) {
+            return;
+        }
+        String normalized = mode.trim().toLowerCase();
+        switch (normalized) {
+            case "implementation":
+                if (!implementationPresent) {
+                    throw new IllegalStateException(
+                            "TCK mode is 'implementation' but "
+                                    + IMPLEMENTATION_PRESENT_PROPERTY
+                                    + " is not true; set -D"
+                                    + IMPLEMENTATION_PRESENT_PROPERTY
+                                    + "=true or omit -D"
+                                    + TCK_MODE_PROPERTY);
+                }
+                return;
+            case "baseline":
+                if (implementationPresent) {
+                    throw new IllegalStateException(
+                            "TCK mode is 'baseline' but "
+                                    + IMPLEMENTATION_PRESENT_PROPERTY
+                                    + " is true; unset the presence flag or set -D"
+                                    + TCK_MODE_PROPERTY
+                                    + "=implementation");
+                }
+                return;
+            default:
+                throw new IllegalStateException(
+                        "Unknown value for "
+                                + TCK_MODE_PROPERTY
+                                + ": '"
+                                + mode
+                                + "'. Accepted values are 'implementation' and 'baseline'");
+        }
     }
 
     /**

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/ImplementationPresentCondition.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/ImplementationPresentCondition.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
+import java.util.Locale;
+
 /**
  * Enables or disables a test based on whether a compatible implementation of
  * the Agentic AI specification is present.
@@ -115,7 +117,7 @@ public class ImplementationPresentCondition implements ExecutionCondition {
         if (mode == null || mode.isBlank()) {
             return;
         }
-        String normalized = mode.trim().toLowerCase();
+        String normalized = mode.trim().toLowerCase(Locale.ROOT);
         switch (normalized) {
             case "implementation":
                 if (!implementationPresent) {

--- a/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/ImplementationPresentConditionTests.java
+++ b/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/junit/extensions/ImplementationPresentConditionTests.java
@@ -1,0 +1,82 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.junit.extensions;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ImplementationPresentCondition#checkMode(String, boolean)}.
+ *
+ * <p>These exercise the TCK's own infrastructure, not the specification.
+ * They are tagged {@code internal} so they do not inflate spec assertion
+ * counts when running with {@code -Dgroups=standalone}.</p>
+ */
+@Tag("internal")
+public class ImplementationPresentConditionTests {
+
+    @Test
+    void unsetModeIsNoOp() {
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode(null, false));
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode(null, true));
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode("", false));
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode("   ", true));
+    }
+
+    @Test
+    void implementationWithoutPresentThrows() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> ImplementationPresentCondition.checkMode("implementation", false));
+        assertTrue(ex.getMessage().contains(ImplementationPresentCondition.IMPLEMENTATION_PRESENT_PROPERTY),
+                "Message must name the presence property");
+    }
+
+    @Test
+    void baselineWithPresentThrows() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> ImplementationPresentCondition.checkMode("baseline", true));
+        assertTrue(ex.getMessage().contains(ImplementationPresentCondition.IMPLEMENTATION_PRESENT_PROPERTY),
+                "Message must name the presence property");
+    }
+
+    @Test
+    void consistentModesDoNotThrow() {
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode("implementation", true));
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode("baseline", false));
+    }
+
+    @Test
+    void unknownValueThrows() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> ImplementationPresentCondition.checkMode("prod", false));
+        assertTrue(ex.getMessage().contains(ImplementationPresentCondition.TCK_MODE_PROPERTY),
+                "Message must name the mode property");
+        assertTrue(ex.getMessage().contains("prod"),
+                "Message must include the offending value");
+    }
+
+    @Test
+    void modeIsCaseInsensitiveAndTrimmed() {
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode(" Implementation ", true));
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode("BASELINE", false));
+        assertDoesNotThrow(() -> ImplementationPresentCondition.checkMode("\tBaSeLiNe\n", false));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> ImplementationPresentCondition.checkMode(" IMPLEMENTATION ", false));
+        assertTrue(ex.getMessage().contains(ImplementationPresentCondition.IMPLEMENTATION_PRESENT_PROPERTY));
+    }
+}


### PR DESCRIPTION
### What

Adds an optional `jakarta.ai.agent.tck.mode` property (`implementation` or `baseline`) that is checked against `jakarta.ai.agent.tck.implementation.present` inside the CDI container. Inconsistent or unknown values fail fast with a clear `IllegalStateException` instead of silently skipping the behavioral suite.

### Why

When a vendor forgets `-Djakarta.ai.agent.tck.implementation.present=true`, all `@RequiresImplementation` assertions skip and the build stays green — a false-compliance risk for a TCK. Fixes #51.

### Scope

- `ImplementationPresentCondition`: `TCK_MODE_PROPERTY` + package-private `checkMode(mode, present)`
- New unit tests: `ImplementationPresentConditionTests`
- `TESTING-GUIDELINE.md` documents both properties and the implementation-mode invocation
- Unset mode preserves today's default baseline behavior; outside-container deferral unchanged

### Validation

- `mvn -pl tck test -Dtest=ImplementationPresentConditionTests` — 6/6 pass
- `mvn -pl tck verify -Pweld-embedded` — BUILD SUCCESS, 51 skipped (baseline unchanged)
- `mvn -pl tck verify -Pweld-embedded -Dit.test=LlmContractTests -Djakarta.ai.agent.tck.mode=implementation` — BUILD FAILURE with clear message naming the presence property