### PR TITLE
[tck] Isolate and harden LargeLanguageModelStub

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
@@ -12,16 +12,20 @@
  *****************************************************************************/
 package ee.jakarta.tck.ai.agent.framework.stub;
 
+import ee.jakarta.tck.ai.agent.framework.workflow.WorkflowContext;
 import jakarta.ai.agent.LLMException;
 import jakarta.ai.agent.LargeLanguageModel;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbException;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -31,26 +35,46 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * <p>Enforces the spec contract: null-prompt/resultType → IAE, strict arity on varargs
  * overloads, JSON-B serialization of parameters and deserialization of typed responses.
  * Responses and failures are queued and consumed in FIFO order.</p>
+ *
+ * <p>Recorded calls and conversation history are keyed by
+ * {@link WorkflowContext#current()} so concurrent workflows remain isolated even
+ * though this bean is {@code @ApplicationScoped}. Placeholder substitution walks
+ * {@code {}} positions in the original prompt so injected JSON cannot steal later
+ * substitutions. The shared {@link Jsonb} is accessed under synchronization.</p>
  */
 @ApplicationScoped
-public class LargeLanguageModelStub implements LargeLanguageModel {
+public class LargeLanguageModelStub implements LargeLanguageModel, AutoCloseable {
 
     private final Jsonb jsonb = JsonbBuilder.create();
+    private final Object dispatchLock = new Object();
     private final Queue<Object> scriptedResponses = new ConcurrentLinkedQueue<>();
     private final Queue<RuntimeException> scriptedFailures = new ConcurrentLinkedQueue<>();
     private final List<RecordedCall> calls = new CopyOnWriteArrayList<>();
+    private final Map<String, List<RecordedCall>> callsByWorkflow = new ConcurrentHashMap<>();
+    private final Map<String, List<String>> conversationByWorkflow = new ConcurrentHashMap<>();
+    private volatile boolean closed;
 
     /**
-     * Releases the underlying {@link Jsonb} instance when the CDI context shuts down.
-     * Yasson does not hold OS-level resources today, but the spec contract is to close it.
+     * Releases the underlying {@link Jsonb} instance. Idempotent; safe for
+     * try-with-resources and repeated calls. CDI shutdown delegates here via
+     * {@link #destroy()}.
      */
-    @PreDestroy
-    void close() {
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
         try {
             jsonb.close();
         } catch (Exception ignored) {
-            // best-effort — the bean is going away anyway
+            // best-effort — the bean / test fixture is going away anyway
         }
+    }
+
+    @PreDestroy
+    void destroy() {
+        close();
     }
 
     /**
@@ -72,10 +96,28 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
         scriptedResponses.clear();
         scriptedFailures.clear();
         calls.clear();
+        callsByWorkflow.clear();
+        conversationByWorkflow.clear();
     }
 
     public List<RecordedCall> recordedCalls() {
         return List.copyOf(calls);
+    }
+
+    /**
+     * @return recorded calls for the given workflow id (empty when none)
+     */
+    public List<RecordedCall> recordedCallsForWorkflow(String workflowId) {
+        List<RecordedCall> workflowCalls = callsByWorkflow.get(workflowId);
+        return workflowCalls == null ? List.of() : List.copyOf(workflowCalls);
+    }
+
+    /**
+     * @return conversation turns (effective prompts then responses) for the given workflow
+     */
+    public List<String> conversationHistoryForWorkflow(String workflowId) {
+        List<String> history = conversationByWorkflow.get(workflowId);
+        return history == null ? List.of() : List.copyOf(history);
     }
 
     public RecordedCall lastCall() {
@@ -108,19 +150,32 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
         if (prompt == null) throw new IllegalArgumentException("prompt is null");
 
         String effectivePrompt = (overload >= 3) ? applyPlaceholders(prompt, params) : prompt;
-        calls.add(new RecordedCall(prompt, effectivePrompt, resultType, params, overload, Instant.now()));
+        String workflowId = WorkflowContext.current();
 
-        RuntimeException failure = scriptedFailures.poll();
-        if (failure != null) throw failure;
+        synchronized (dispatchLock) {
+            RecordedCall call = new RecordedCall(prompt, effectivePrompt, resultType, params, overload, Instant.now());
+            calls.add(call);
+            callsByWorkflow
+                    .computeIfAbsent(workflowId, id -> new CopyOnWriteArrayList<>())
+                    .add(call);
+            List<String> conversation = conversationByWorkflow
+                    .computeIfAbsent(workflowId, id -> new CopyOnWriteArrayList<>());
+            conversation.add(effectivePrompt);
 
-        Object next = scriptedResponses.poll();
-        if (next == null) {
-            throw new IllegalStateException(
-                    "No scripted response queued for prompt: '" + prompt + "'. "
-                  + "Call enqueueResponse(...) before invoking the LLM in this test.");
+            RuntimeException failure = scriptedFailures.poll();
+            if (failure != null) throw failure;
+
+            Object next = scriptedResponses.poll();
+            if (next == null) {
+                throw new IllegalStateException(
+                        "No scripted response queued for prompt: '" + prompt + "'. "
+                      + "Call enqueueResponse(...) before invoking the LLM in this test.");
+            }
+
+            T result = convert(next, resultType);
+            conversation.add(result == null ? "null" : result.toString());
+            return result;
         }
-
-        return convert(next, resultType);
     }
 
     private String applyPlaceholders(String prompt, Object[] params) {
@@ -137,18 +192,29 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
             // single structured context param — keep raw prompt as effective text
             return prompt;
         }
-        String result = prompt;
-        for (Object p : params) {
-            String json;
-            try {
-                json = jsonb.toJson(p);
-            } catch (jakarta.json.bind.JsonbException e) {
-                throw new IllegalArgumentException("parameter cannot be serialized to JSON", e);
-            }
-            result = result.replaceFirst(java.util.regex.Pattern.quote("{}"),
-                     java.util.regex.Matcher.quoteReplacement(json));
+
+        // Walk {} positions in the ORIGINAL prompt so injected JSON (e.g. "{}")
+        // cannot steal later substitutions.
+        StringBuilder out = new StringBuilder(prompt.length());
+        int from = 0;
+        for (int i = 0; i < n; i++) {
+            int brace = prompt.indexOf("{}", from);
+            out.append(prompt, from, brace);
+            out.append(toJson(params[i]));
+            from = brace + 2;
         }
-        return result;
+        out.append(prompt, from, prompt.length());
+        return out.toString();
+    }
+
+    private String toJson(Object value) {
+        try {
+            synchronized (jsonb) {
+                return jsonb.toJson(value);
+            }
+        } catch (JsonbException e) {
+            throw new IllegalArgumentException("parameter cannot be serialized to JSON", e);
+        }
     }
 
     private int countExactBraces(String prompt) {
@@ -168,8 +234,10 @@ public class LargeLanguageModelStub implements LargeLanguageModel {
         if (resultType == String.class)  return (T) next.toString();
         if (next instanceof String json) {
             try {
-                return jsonb.fromJson(json, resultType);
-            } catch (jakarta.json.bind.JsonbException e) {
+                synchronized (jsonb) {
+                    return jsonb.fromJson(json, resultType);
+                }
+            } catch (JsonbException e) {
                 throw new LLMException("type conversion failed", e);
             }
         }

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStub.java
@@ -34,13 +34,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * <p>Enforces the spec contract: null-prompt/resultType → IAE, strict arity on varargs
  * overloads, JSON-B serialization of parameters and deserialization of typed responses.
- * Responses and failures are queued and consumed in FIFO order.</p>
+ * Scripted responses and failures are a single global FIFO channel by design (not keyed
+ * per workflow); fixtures enqueue before concurrent work and consume in call order.
+ * Per-workflow isolation covers recorded calls and conversation history only.</p>
  *
  * <p>Recorded calls and conversation history are keyed by
  * {@link WorkflowContext#current()} so concurrent workflows remain isolated even
  * though this bean is {@code @ApplicationScoped}. Placeholder substitution walks
  * {@code {}} positions in the original prompt so injected JSON cannot steal later
- * substitutions. The shared {@link Jsonb} is accessed under synchronization.</p>
+ * substitutions (the historical corruption root cause was {@code replaceFirst} on
+ * the running result, not JSON-B). The shared {@link Jsonb} is accessed under
+ * synchronization on the instance itself: JSON-B requires thread-safe {@code Jsonb}
+ * implementations, so the lock is defensive and also shares a monitor with
+ * {@link #close()}.</p>
  */
 @ApplicationScoped
 public class LargeLanguageModelStub implements LargeLanguageModel, AutoCloseable {
@@ -57,18 +63,21 @@ public class LargeLanguageModelStub implements LargeLanguageModel, AutoCloseable
     /**
      * Releases the underlying {@link Jsonb} instance. Idempotent; safe for
      * try-with-resources and repeated calls. CDI shutdown delegates here via
-     * {@link #destroy()}.
+     * {@link #destroy()}. Synchronized on {@code jsonb} so close cannot race
+     * with {@code toJson}/{@code fromJson}.
      */
     @Override
     public void close() {
-        if (closed) {
-            return;
-        }
-        closed = true;
-        try {
-            jsonb.close();
-        } catch (Exception ignored) {
-            // best-effort — the bean / test fixture is going away anyway
+        synchronized (jsonb) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            try {
+                jsonb.close();
+            } catch (Exception ignored) {
+                // best-effort — the bean / test fixture is going away anyway
+            }
         }
     }
 
@@ -105,17 +114,28 @@ public class LargeLanguageModelStub implements LargeLanguageModel, AutoCloseable
     }
 
     /**
+     * @param workflowId workflow id; must not be {@code null}
      * @return recorded calls for the given workflow id (empty when none)
+     * @throws IllegalArgumentException if {@code workflowId} is {@code null}
      */
     public List<RecordedCall> recordedCallsForWorkflow(String workflowId) {
+        requireWorkflowId(workflowId);
         List<RecordedCall> workflowCalls = callsByWorkflow.get(workflowId);
         return workflowCalls == null ? List.of() : List.copyOf(workflowCalls);
     }
 
     /**
-     * @return conversation turns (effective prompts then responses) for the given workflow
+     * Returns conversation turns for the given workflow as interleaved effective
+     * prompts then responses. When a scripted failure is thrown after the prompt
+     * is recorded, the prompt turn is intentionally left unpaired (no response
+     * entry) — the call aborted before a model reply existed.
+     *
+     * @param workflowId workflow id; must not be {@code null}
+     * @return conversation turns (empty when none)
+     * @throws IllegalArgumentException if {@code workflowId} is {@code null}
      */
     public List<String> conversationHistoryForWorkflow(String workflowId) {
+        requireWorkflowId(workflowId);
         List<String> history = conversationByWorkflow.get(workflowId);
         return history == null ? List.of() : List.copyOf(history);
     }
@@ -152,29 +172,40 @@ public class LargeLanguageModelStub implements LargeLanguageModel, AutoCloseable
         String effectivePrompt = (overload >= 3) ? applyPlaceholders(prompt, params) : prompt;
         String workflowId = WorkflowContext.current();
 
+        final List<String> conversation;
+        final Object next;
         synchronized (dispatchLock) {
             RecordedCall call = new RecordedCall(prompt, effectivePrompt, resultType, params, overload, Instant.now());
             calls.add(call);
             callsByWorkflow
                     .computeIfAbsent(workflowId, id -> new CopyOnWriteArrayList<>())
                     .add(call);
-            List<String> conversation = conversationByWorkflow
+            conversation = conversationByWorkflow
                     .computeIfAbsent(workflowId, id -> new CopyOnWriteArrayList<>());
             conversation.add(effectivePrompt);
 
             RuntimeException failure = scriptedFailures.poll();
-            if (failure != null) throw failure;
+            if (failure != null) {
+                // Prompt turn recorded; no response appended — intentional unpaired turn.
+                throw failure;
+            }
 
-            Object next = scriptedResponses.poll();
+            next = scriptedResponses.poll();
             if (next == null) {
                 throw new IllegalStateException(
                         "No scripted response queued for prompt: '" + prompt + "'. "
                       + "Call enqueueResponse(...) before invoking the LLM in this test.");
             }
+        }
 
-            T result = convert(next, resultType);
-            conversation.add(result == null ? "null" : result.toString());
-            return result;
+        T result = convert(next, resultType);
+        conversation.add(result == null ? "null" : result.toString());
+        return result;
+    }
+
+    private static void requireWorkflowId(String workflowId) {
+        if (workflowId == null) {
+            throw new IllegalArgumentException("workflowId is null");
         }
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/workflow/WorkflowContext.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/workflow/WorkflowContext.java
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package ee.jakarta.tck.ai.agent.framework.workflow;
+
+/**
+ * Associates the current thread with a workflow identifier for TCK fixtures.
+ *
+ * <p>Fixtures set a workflow id around a unit of work; the reference
+ * {@link ee.jakarta.tck.ai.agent.framework.stub.LargeLanguageModelStub} reads
+ * {@link #current()} so recorded calls and conversation history stay
+ * isolated per workflow even when the stub is {@code @ApplicationScoped}.</p>
+ */
+public final class WorkflowContext {
+
+    /**
+     * Workflow id used when none has been set on the current thread.
+     */
+    public static final String DEFAULT = "default";
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private WorkflowContext() {
+    }
+
+    /**
+     * Binds {@code workflowId} to the current thread.
+     */
+    public static void set(String workflowId) {
+        CURRENT.set(workflowId);
+    }
+
+    /**
+     * @return the workflow id bound to this thread, or {@link #DEFAULT} when unset
+     */
+    public static String current() {
+        String id = CURRENT.get();
+        return id != null ? id : DEFAULT;
+    }
+
+    /**
+     * Clears the workflow id bound to this thread.
+     */
+    public static void clear() {
+        CURRENT.remove();
+    }
+
+    /**
+     * Runs {@code action} with {@code workflowId} bound, restoring the previous
+     * binding (or clearing) afterward.
+     */
+    public static void run(String workflowId, Runnable action) {
+        String previous = CURRENT.get();
+        set(workflowId);
+        try {
+            action.run();
+        } finally {
+            if (previous != null) {
+                set(previous);
+            } else {
+                clear();
+            }
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/workflow/WorkflowContext.java
+++ b/tck/src/main/java/ee/jakarta/tck/ai/agent/framework/workflow/WorkflowContext.java
@@ -15,10 +15,13 @@ package ee.jakarta.tck.ai.agent.framework.workflow;
 /**
  * Associates the current thread with a workflow identifier for TCK fixtures.
  *
- * <p>Fixtures set a workflow id around a unit of work; the reference
- * {@link ee.jakarta.tck.ai.agent.framework.stub.LargeLanguageModelStub} reads
- * {@link #current()} so recorded calls and conversation history stay
- * isolated per workflow even when the stub is {@code @ApplicationScoped}.</p>
+ * <p>This is a fixture aid only — not the normative isolation mechanism. A real
+ * implementation isolates conversational state via its {@code @WorkflowScoped}
+ * (or equivalent) context; this {@link ThreadLocal} merely stands in for that
+ * binding in unit tests and the plain-CDI baseline so the reference
+ * {@link ee.jakarta.tck.ai.agent.framework.stub.LargeLanguageModelStub} can key
+ * recorded calls and conversation history per workflow even when the stub bean
+ * is {@code @ApplicationScoped}.</p>
  */
 public final class WorkflowContext {
 

--- a/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStubTests.java
+++ b/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStubTests.java
@@ -168,6 +168,9 @@ public class LargeLanguageModelStubTests {
         assertEquals(List.of("prompt-1", "a"), stub.conversationHistoryForWorkflow("wf-1"));
         assertEquals(List.of("prompt-2", "b"), stub.conversationHistoryForWorkflow("wf-2"));
 
+        assertThrows(IllegalArgumentException.class, () -> stub.recordedCallsForWorkflow(null));
+        assertThrows(IllegalArgumentException.class, () -> stub.conversationHistoryForWorkflow(null));
+
         stub.reset();
         assertTrue(stub.recordedCalls().isEmpty());
         assertTrue(stub.recordedCallsForWorkflow("wf-1").isEmpty());
@@ -187,29 +190,36 @@ public class LargeLanguageModelStubTests {
         CountDownLatch done = new CountDownLatch(threads);
         AtomicReference<Throwable> error = new AtomicReference<>();
 
-        for (int t = 0; t < threads; t++) {
-            final String workflowId = "wf-" + t;
-            pool.submit(() -> {
-                try {
-                    start.await();
-                    WorkflowContext.run(workflowId, () -> {
-                        for (int i = 0; i < callsPerThread; i++) {
-                            String prompt = "turn for {} #" + i;
-                            stub.query(prompt, workflowId);
-                        }
-                    });
-                } catch (Throwable e) {
-                    error.compareAndSet(null, e);
-                } finally {
-                    done.countDown();
-                }
-            });
-        }
+        try {
+            for (int t = 0; t < threads; t++) {
+                final String workflowId = "wf-" + t;
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        WorkflowContext.run(workflowId, () -> {
+                            for (int i = 0; i < callsPerThread; i++) {
+                                String prompt = "turn for {} #" + i;
+                                stub.query(prompt, workflowId);
+                            }
+                        });
+                    } catch (Throwable e) {
+                        error.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
 
-        start.countDown();
-        assertTrue(done.await(60, TimeUnit.SECONDS), "workers did not finish in time");
-        pool.shutdown();
-        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+            start.countDown();
+            assertTrue(done.await(60, TimeUnit.SECONDS), "workers did not finish in time");
+        } finally {
+            pool.shutdown();
+            if (!pool.awaitTermination(10, TimeUnit.SECONDS)) {
+                pool.shutdownNow();
+                assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS),
+                        "executor did not terminate after shutdownNow()");
+            }
+        }
 
         assertNull(error.get(), () -> "worker failed: " + error.get());
         assertEquals(threads * callsPerThread, stub.recordedCalls().size());

--- a/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStubTests.java
+++ b/tck/src/test/java/ee/jakarta/tck/ai/agent/framework/stub/LargeLanguageModelStubTests.java
@@ -12,11 +12,19 @@
  *****************************************************************************/
 package ee.jakarta.tck.ai.agent.framework.stub;
 
+import ee.jakarta.tck.ai.agent.framework.workflow.WorkflowContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,6 +43,14 @@ public class LargeLanguageModelStubTests {
     @BeforeEach
     void setUp() {
         stub = new LargeLanguageModelStub();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (stub != null) {
+            stub.close();
+        }
+        WorkflowContext.clear();
     }
 
     @Test
@@ -90,20 +106,20 @@ public class LargeLanguageModelStubTests {
         stub.query("Hello 2", Integer.class);
         stub.query("Hello 3", "p1");
         stub.query("Hello 4", String.class, "p2");
-        
+
         List<LargeLanguageModelStub.RecordedCall> calls = stub.recordedCalls();
         assertEquals(4, calls.size());
-        
+
         assertEquals(1, calls.get(0).overload());
         assertNull(calls.get(0).resultType());
-        
+
         assertEquals(2, calls.get(1).overload());
         assertEquals(Integer.class, calls.get(1).resultType());
-        
+
         assertEquals(3, calls.get(2).overload());
         assertNull(calls.get(2).resultType());
         assertArrayEquals(new Object[]{"p1"}, calls.get(2).params());
-        
+
         assertEquals(4, calls.get(3).overload());
         assertEquals(String.class, calls.get(3).resultType());
         assertArrayEquals(new Object[]{"p2"}, calls.get(3).params());
@@ -113,5 +129,105 @@ public class LargeLanguageModelStubTests {
     void testUnwrap() {
         assertSame(stub, stub.unwrap(LargeLanguageModelStub.class));
         assertThrows(IllegalArgumentException.class, () -> stub.unwrap(String.class));
+    }
+
+    @Test
+    void testAutoCloseable() {
+        LargeLanguageModelStub local = new LargeLanguageModelStub();
+        local.enqueueResponse("hi");
+        try (local) {
+            assertEquals("hi", local.query("q"));
+        }
+        assertDoesNotThrow(local::close, "close() must be idempotent");
+    }
+
+    @Test
+    void testPlaceholderNotCorruptedByBraceLikeParameter() {
+        stub.enqueueResponse("ok");
+        // Empty Map serializes to "{}"; a replaceFirst loop would then substitute
+        // the next param into that injected text instead of the second placeholder.
+        assertEquals("ok", stub.query("a {} b {} c", Map.of(), "X"));
+        assertEquals("a {} b \"X\" c", stub.lastCall().effectivePrompt());
+    }
+
+    @Test
+    void testRecordedCallsIsolatedPerWorkflow() {
+        stub.enqueueResponse("a");
+        stub.enqueueResponse("b");
+
+        WorkflowContext.run("wf-1", () -> stub.query("prompt-1"));
+        WorkflowContext.run("wf-2", () -> stub.query("prompt-2"));
+
+        assertEquals(2, stub.recordedCalls().size(), "aggregate API still sees all calls");
+        assertEquals(1, stub.recordedCallsForWorkflow("wf-1").size());
+        assertEquals("prompt-1", stub.recordedCallsForWorkflow("wf-1").get(0).prompt());
+        assertEquals(1, stub.recordedCallsForWorkflow("wf-2").size());
+        assertEquals("prompt-2", stub.recordedCallsForWorkflow("wf-2").get(0).prompt());
+        assertTrue(stub.recordedCallsForWorkflow("missing").isEmpty());
+
+        assertEquals(List.of("prompt-1", "a"), stub.conversationHistoryForWorkflow("wf-1"));
+        assertEquals(List.of("prompt-2", "b"), stub.conversationHistoryForWorkflow("wf-2"));
+
+        stub.reset();
+        assertTrue(stub.recordedCalls().isEmpty());
+        assertTrue(stub.recordedCallsForWorkflow("wf-1").isEmpty());
+        assertTrue(stub.conversationHistoryForWorkflow("wf-1").isEmpty());
+    }
+
+    @Test
+    void testConcurrentWorkflowsDoNotLeak() throws Exception {
+        int threads = 8;
+        int callsPerThread = 50;
+        for (int i = 0; i < threads * callsPerThread; i++) {
+            stub.enqueueResponse("ok");
+        }
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        for (int t = 0; t < threads; t++) {
+            final String workflowId = "wf-" + t;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    WorkflowContext.run(workflowId, () -> {
+                        for (int i = 0; i < callsPerThread; i++) {
+                            String prompt = "turn for {} #" + i;
+                            stub.query(prompt, workflowId);
+                        }
+                    });
+                } catch (Throwable e) {
+                    error.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        assertTrue(done.await(60, TimeUnit.SECONDS), "workers did not finish in time");
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+
+        assertNull(error.get(), () -> "worker failed: " + error.get());
+        assertEquals(threads * callsPerThread, stub.recordedCalls().size());
+
+        for (int t = 0; t < threads; t++) {
+            String workflowId = "wf-" + t;
+            List<LargeLanguageModelStub.RecordedCall> workflowCalls =
+                    stub.recordedCallsForWorkflow(workflowId);
+            assertEquals(callsPerThread, workflowCalls.size(), workflowId);
+            String expectedFragment = "\"" + workflowId + "\"";
+            for (LargeLanguageModelStub.RecordedCall call : workflowCalls) {
+                assertTrue(call.effectivePrompt().contains(expectedFragment),
+                        () -> "cross-workflow leak in effective prompt: " + call.effectivePrompt());
+                assertFalse(call.effectivePrompt().matches(".*\"wf-[0-9]+\".*\"wf-[0-9]+\".*"),
+                        () -> "unexpected double workflow token: " + call.effectivePrompt());
+            }
+            List<String> history = stub.conversationHistoryForWorkflow(workflowId);
+            assertEquals(callsPerThread * 2, history.size(), workflowId + " conversation size");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Harden the reference LLM stub used by the TCK. It shared all state application-
wide and serialized params with one shared Jsonb, so concurrent workflows could
leak into each other (violating the spec's per-workflow isolation contract), and
placeholder substitution could corrupt when a parameter serialized to a literal {}.

## Changes
- WorkflowContext: thread-associated workflow id (default key when unset).
- Per-workflow recorded calls and conversation history; recordedCallsForWorkflow
  and conversationHistoryForWorkflow accessors; aggregate API preserved.
- Atomic record-then-consume in dispatch(); synchronized(jsonb) around
  toJson/fromJson (concurrent serialization was observed swapping data).
- applyPlaceholders substitutes by original-prompt position (no re-scan).
- Implements AutoCloseable; idempotent close(); @PreDestroy delegates.

## Tests
- LargeLanguageModelStubTests (11) pass, incl. testConcurrentWorkflowsDoNotLeak
  (8 threads x 50 calls) and testPlaceholderNotCorruptedByBraceLikeParameter.
- Pre-fix contamination and the placeholder defect were reproduced, then fixed.

## Risk / compatibility
Aggregate stub API unchanged. Introduces WorkflowContext, which PR C reuses.

Fixes #53