### PR TITLE
Add JSR 354 MonetaryAmount to BankTransaction

### DIFF
--- a/examples/fraud-detection/pom.xml
+++ b/examples/fraud-detection/pom.xml
@@ -34,5 +34,10 @@
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.money</groupId>
+            <artifactId>money-api</artifactId>
+            <version>1.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/examples/fraud-detection/src/main/java/ee/jakarta/examples/ai/agent/frauddetection/BankTransaction.java
+++ b/examples/fraud-detection/src/main/java/ee/jakarta/examples/ai/agent/frauddetection/BankTransaction.java
@@ -13,6 +13,44 @@
  *****************************************************************************/
 package ee.jakarta.examples.ai.agent.frauddetection;
 
+import javax.money.MonetaryAmount;
+
 public class BankTransaction {
-    // Add fields and methods as needed
+
+    private String id;
+    private MonetaryAmount amount;
+    private String merchant;
+    private String location;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public MonetaryAmount getAmount() {
+        return amount;
+    }
+
+    public void setAmount(MonetaryAmount amount) {
+        this.amount = amount;
+    }
+
+    public String getMerchant() {
+        return merchant;
+    }
+
+    public void setMerchant(String merchant) {
+        this.merchant = merchant;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
 }


### PR DESCRIPTION
## Summary

- Add JSR 354 `MonetaryAmount` to the `BankTransaction` example.
- Add the required `javax.money:money-api:1.1` dependency.
- Add basic getters and setters for the transaction fields.

## Verification

- `git diff --check`
- `mvn -pl examples/fraud-detection -am clean test`

Build completed successfully.

Fixes #11