### PR TITLE
Move the main build onto Node 24 actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,15 +16,15 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
             - name: Setup Java
-              uses: actions/setup-java@v4
+              uses: actions/setup-java@v6
               with:
                   distribution: 'temurin'
                   java-version: 17
 
             - name: Cache Maven packages
-              uses: actions/cache@v4
+              uses: actions/cache@v6
               with:
                   path: ~/.m2/repository
                   key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -155,7 +155,7 @@ jobs:
                   exit 1
 
             - name: Upload DEPENDENCIES
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               if: always()
               with:
                   name: DEPENDENCIES


### PR DESCRIPTION
Node 20 is end of life on the GitHub-hosted runners, so every `Main build` run ends with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, actions/setup-java@v4, actions/upload-artifact@v4.

This takes the majors that declare `node24` natively.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-java` | v4 | v6 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |

The intervening majors are runtime and ESM migrations. None changes an input this workflow sets:

- **checkout** — v6 moved credential persistence to a separate file; v7 blocks fork-PR checkout for `pull_request_target` and `workflow_run`, neither of which this workflow uses.
- **setup-java** — v5 is Node 24; v6 migrates Zulu to the Azul Metadata API and renames `jdkFile` to `jdk-file` behind a deprecated alias. We pass `distribution: temurin` and `java-version: 17`, both unchanged.
- **cache** — v5 is Node 24, v6 is ESM. `path`, `key` and `restore-keys` are unchanged.
- **upload-artifact** — v5/v6 are Node 24; v7 is ESM plus an optional `archive` input. `name` and `path` are unchanged.

All four require Actions Runner 2.327.1 or newer, which the hosted runners satisfy.

The Pages workflow on `gh-pages` got the equivalent bump in ffbc32e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)