### PR TITLE
Document where the project site lives and how it is built

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,14 @@ TCK tests live in `src/main/java` (not `src/test/java`) and are compiled to clas
 - `api` and `tck` are published; `spec`, `examples` and the aggregator (beyond its pom) are not. Staging suppresses modules with `maven.deploy.skip`, snapshot publishing with `skipPublishing` — a module that should not be published needs **both**. The parent pom is published because `api` and `tck` declare it as their parent; this matches other Jakarta specs (`jakarta.data-parent`, `jakarta.enterprise.cdi-parent`).
 - CycloneDX SBOMs are generated for the published modules only: `cyclonedx.skip` is `true` in the root pom and `false` in `api` and `tck`. The aggregator's own BOM would otherwise describe unpublished modules and GAVs that never reach a repository.
 - Do not reintroduce a `stage-release` javadoc `<skip>` in `tck`: Maven Central rejects a release without a javadoc jar.
+
+## Project site (`gh-pages` branch)
+
+The site at https://jakartaee.github.io/agentic-ai/ is **not** built from `main`. It lives on the orphan `gh-pages` branch, which shares no history with `main` and is not a Maven module.
+
+- Editable sources are `content.html` (home page body), `tutorial/index.html` (a standalone self-styled page with none of the jakarta.ee chrome) and `assets/`.
+- `index.html` is **generated and not committed** — `build-site.py` wraps `content.html` in the Eclipse toolbar, mega-menu and Solstice footer sliced out of `ref-specpage.html`, a saved copy of a live jakarta.ee page. It is `.gitignore`d and assembled by `.github/workflows/pages.yml` on every push to the branch. Never hand-edit it.
+- The home page hero copy (`TITLE`, `SUMMARY` and the jumbotron markup) is in `build-site.py`, not `content.html`.
+- Refresh the chrome to match a jakarta.ee redesign by re-saving the reference page and committing it: `curl -s -L https://jakarta.ee/specifications/agentic-ai/1.0/ -o ref-specpage.html`.
+- GitHub Pages is configured with `build_type: workflow`, so the branch is what CI builds from rather than what is served directly. The `source.branch` value in the Pages config is vestigial; the `github-pages` environment's deployment branch policy is what actually gates deploys.
+- `upload-pages-artifact` has excluded dotfiles since v4, so `.nojekyll` no longer reaches the artifact. Nothing needs it — Jekyll only ran under the old branch-based build.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ The project aims for the broadest industry consensus possible by engaging as man
 
 Our mailing list is [agentic-ai-dev@eclipse.org](https://accounts.eclipse.org/mailing-list/agentic-ai-dev). You are also welcome to join the agentic-ai channel on the [Jakarta EE Development Slack](https://eclipsefoundationhq.slack.com/join/shared_invite/zt-crh7mheq-3on2tophEuvQTUGidEAWlg?u=eaf9e1f06f194eadc66788a85&id=98ae69e304&join=Join#/shared-invite/email).
 
+## Project Website
+
+The project website is at [jakartaee.github.io/agentic-ai](https://jakartaee.github.io/agentic-ai/), which also hosts an [interactive tutorial](https://jakartaee.github.io/agentic-ai/tutorial/).
+
+Its sources are on the orphan `gh-pages` branch rather than `main`. Edit `content.html` for the home page body or `tutorial/index.html` for the tutorial; the published `index.html` is assembled from `content.html` and a saved copy of the jakarta.ee page shell by `build-site.py`, which runs in CI on every push to that branch.
+
 ## Directories
 
 - [<b>api/</b>](api/): Jakarta Agentic AI API (source code)


### PR DESCRIPTION
Nothing on `main` mentioned the project site, so a contributor cloning the repo had no way to find it — the sources are on the orphan `gh-pages` branch, which shares no history with `main` and holds no Maven module.

- **README** gains a short *Project Website* section with the site and tutorial links and which files to edit.
- **CLAUDE.md** gains a *Project site (`gh-pages` branch)* section covering the parts that are easy to get wrong.

The important one: `index.html` is **generated by `build-site.py` in CI and no longer committed** (untracked in c5e8f4d on `gh-pages`). The files to edit are `content.html` and `tutorial/index.html`. Before the build ran in CI, an edit to `content.html` silently never shipped — the published home page sat two commits stale for exactly that reason.

Docs only; no code or build changes.