### PR TITLE
Refresh DEPENDENCIES for the current Eclipse Dash output

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,33 +1,33 @@
-maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, BSD-3-Clause OR EPL-2.0 OR GPL-2.0-only WITH Classpath-Exception-2.0, approved, #8015
 maven/mavencentral/jakarta.agentic-ai/jakarta.agentic-ai-api/1.0.0-SNAPSHOT, EPL-2.0, approved, ee4j.agentic-ai
-maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
+maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #8018
 maven/mavencentral/jakarta.authentication/jakarta.authentication-api/3.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.authentication
 maven/mavencentral/jakarta.authorization/jakarta.authorization-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.authorization
 maven/mavencentral/jakarta.batch/jakarta.batch-api/2.1.1, Apache-2.0, approved, ee4j.batch
 maven/mavencentral/jakarta.ejb/jakarta.ejb-api/4.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ejb
 maven/mavencentral/jakarta.el/jakarta.el-api/5.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.el
-maven/mavencentral/jakarta.enterprise/jakarta.enterprise.cdi-api/4.0.1, Apache-2.0, approved, ee4j.cdi
-maven/mavencentral/jakarta.enterprise/jakarta.enterprise.lang-model/4.0.1, Apache-2.0, approved, ee4j.cdi
+maven/mavencentral/jakarta.enterprise/jakarta.enterprise.cdi-api/4.0.1, Apache-2.0, approved, #9117
+maven/mavencentral/jakarta.enterprise/jakarta.enterprise.lang-model/4.0.1, Apache-2.0, approved, #9110
 maven/mavencentral/jakarta.faces/jakarta.faces-api/4.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.faces
-maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, ee4j.cdi
-maven/mavencentral/jakarta.interceptor/jakarta.interceptor-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.interceptors
-maven/mavencentral/jakarta.jms/jakarta.jms-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.messaging
-maven/mavencentral/jakarta.json.bind/jakarta.json.bind-api/3.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
-maven/mavencentral/jakarta.json/jakarta.json-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
+maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, #25006
+maven/mavencentral/jakarta.interceptor/jakarta.interceptor-api/2.1.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #9112
+maven/mavencentral/jakarta.jms/jakarta.jms-api/3.1.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #12832
+maven/mavencentral/jakarta.json.bind/jakarta.json.bind-api/3.0.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #12834
+maven/mavencentral/jakarta.json/jakarta.json-api/2.1.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7907
 maven/mavencentral/jakarta.mail/jakarta.mail-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.mail
-maven/mavencentral/jakarta.persistence/jakarta.persistence-api/3.1.0, EPL-2.0 OR BSD-3-Clause, approved, ee4j.jpa
+maven/mavencentral/jakarta.persistence/jakarta.persistence-api/3.1.0, EPL-2.0 OR BSD-3-Clause AND (EPL-2.0 OR BSD-3-Clause AND BSD-3-Clause), approved, #7696
 maven/mavencentral/jakarta.platform/jakarta.jakartaee-api/10.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jakartaee-platform
 maven/mavencentral/jakarta.platform/jakarta.jakartaee-web-api/10.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jakartaee-platform
-maven/mavencentral/jakarta.resource/jakarta.resource-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jca
+maven/mavencentral/jakarta.resource/jakarta.resource-api/2.1.0, EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0), approved, #12100
 maven/mavencentral/jakarta.security.enterprise/jakarta.security.enterprise-api/3.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.security
 maven/mavencentral/jakarta.servlet.jsp.jstl/jakarta.servlet.jsp.jstl-api/3.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jstl
 maven/mavencentral/jakarta.servlet.jsp/jakarta.servlet.jsp-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsp
 maven/mavencentral/jakarta.servlet/jakarta.servlet-api/6.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.servlet
-maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jta
+maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.websocket/jakarta.websocket-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.websocket
 maven/mavencentral/jakarta.websocket/jakarta.websocket-client-api/2.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.websocket
-maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
+maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #8019
 maven/mavencentral/javax.money/money-api/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.bytebuddy/byte-buddy/1.18.3, Apache-2.0 AND BSD-3-Clause, approved, #24658
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641


### PR DESCRIPTION
The Eclipse Dash license tool changed how it formats its summary, so the generated manifest no longer matches the committed one. `Verify DEPENDENCIES is up to date` now fails on **every** build — including unmodified `main`, which I confirmed with a `workflow_dispatch` run: https://github.com/jakartaee/agentic-ai/actions/runs/33902496785

This currently blocks every open PR, so it needs to land before anything else can merge.

## What changed in the tool's output

Two purely cosmetic differences, 13 of 57 lines:

| | Before | After |
|---|---|---|
| Last column | Eclipse project id — `ee4j.jaf`, `ee4j.cdi` | IP issue number — `#8015`, `#9117` |
| License expressions | `EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0` | `EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0` |
| Parenthesization | `EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0` | `EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)` |

## This is not a licensing change

- The dependency set is byte-for-byte identical — same 57 GAVs, verified by diffing the first column of both files
- All 57 entries are still `approved`; nothing moved to `restricted` or `review`
- No pom or dependency was touched in this PR

The regenerated file is taken verbatim from the `DEPENDENCIES` artifact the CI run produces, and it is identical across two independent runs, so the output is deterministic.